### PR TITLE
Fix a slow redirect issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@ember/test-helpers": "^2.9.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-submission-form-fields": "^2.11.0",
+        "@lblod/ember-submission-form-fields": "^2.12.2",
         "broccoli-asset-rev": "^3.0.0",
         "codemirror": "^6.0.1",
         "codemirror-lang-turtle": "^0.0.2",
@@ -3516,18 +3516,17 @@
       "dev": true
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.11.0.tgz",
-      "integrity": "sha512-EAvrSMRHw6PuLreWyARddFDu2nE/nfxzk8qghHce4HM5+wYekXPSZ4Y+cuhALgZEolQXXl6/fw1pDxZS4Hco9g==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.12.2.tgz",
+      "integrity": "sha512-mY2tWV4YOlUw5iT8YXZuZiQ6CBJKKkShcFHeEiIPD/OQuL3FU9ri63eqZkwif1MC7MBNeEIWiZdWO1mUz0LE6A==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",
-        "clipboardy": "^2.3.0",
-        "ember-auto-import": "^2.4.3",
+        "clipboardy": "^3.0.0",
+        "ember-auto-import": "^2.6.3",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.1.1",
-        "ember-concurrency": "^2.0.0",
-        "ember-math-helpers": "^2.18.1",
+        "ember-cli-htmlbars": "^6.2.0",
+        "ember-concurrency": "^2.3.2 || ^3.0.0",
         "ember-truth-helpers": "^3.0.0",
         "forking-store": "^2.0.0",
         "rdflib": "^2.2.19",
@@ -3537,9 +3536,10 @@
         "node": "14.* || 16.* || >= 18"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.5.0",
-        "ember-data": "^3.16.0 || ^4.0.0",
-        "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0"
+        "@appuniversum/ember-appuniversum": "^2.6.0",
+        "ember-data": "^3.16.0 || ^4.0.0 || ^5.0.0",
+        "ember-power-select": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "ember-source": "^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@lblod/submission-form-helpers": {
@@ -9957,14 +9957,85 @@
       }
     },
     "node_modules/clipboardy": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
-      "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
       "dev": true,
       "dependencies": {
-        "arch": "^2.1.1",
-        "execa": "^1.0.0",
-        "is-wsl": "^2.1.1"
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/clipboardy/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/clipboardy/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -21461,9 +21532,9 @@
       }
     },
     "node_modules/forking-store": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/forking-store/-/forking-store-2.0.0.tgz",
-      "integrity": "sha512-pW0/aWYYLXjLt4AqNYEoa4HxtAEKc2ljIA3zBMeJy6ia8ZLdG/oQ8aS0mwtWAK6jyLT/c2EsOM3ta2RsLzseYA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/forking-store/-/forking-store-2.1.0.tgz",
+      "integrity": "sha512-Dnw+ru+N5Zi6CP9j3EUacxpVbwJcAEys2R5PBdGeBoZdl8kN9FX3FMQAbfuHz/uGGDKTiagC/yL/ZZhrU3IiIg==",
       "dev": true,
       "dependencies": {
         "rdflib": "^2.2.19"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@ember/test-helpers": "^2.9.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-submission-form-fields": "^2.11.0",
+    "@lblod/ember-submission-form-fields": "^2.12.2",
     "broccoli-asset-rev": "^3.0.0",
     "codemirror": "^6.0.1",
     "codemirror-lang-turtle": "^0.0.2",


### PR DESCRIPTION
Redirecting to the overview page from a very large form resulted in the browser freezing for several seconds. The underlying issue is observer system in the forking-store which gets used by the form fields addon. The latest patch fixes that issue upstream, so we update to that version to also fix the issue here.

With this PR leaving the details page of the "Big form" should no longer freeze the browser.