### PR TITLE
Fix issue where the browser freezes after editing a field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36927,9 +36927,9 @@
       }
     },
     "node_modules/forking-store": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/forking-store/-/forking-store-2.1.0.tgz",
-      "integrity": "sha512-Dnw+ru+N5Zi6CP9j3EUacxpVbwJcAEys2R5PBdGeBoZdl8kN9FX3FMQAbfuHz/uGGDKTiagC/yL/ZZhrU3IiIg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/forking-store/-/forking-store-2.1.1.tgz",
+      "integrity": "sha512-Bceuk+2Wp+XKGYPwmHbKDnNFtQSxjOMmIwIdbFta8PtujbrnSFPR0JVOsVUbWril3LG+UNhWZhScKL0Owp5ZbQ==",
       "dev": true,
       "dependencies": {
         "rdflib": "^2.2.19"


### PR DESCRIPTION
We accidentally introduced a regression when fixing the other freezing issue. The forking-store update should fix that again.