### PR TITLE
Add listing item reordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@embroider/webpack": "^3.0.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@lblod/ember-submission-form-fields": "^2.13.0",
+        "@lblod/ember-submission-form-fields": "^2.14.1",
         "broccoli-asset-rev": "^3.0.0",
         "codemirror": "^6.0.1",
         "codemirror-lang-turtle": "^0.0.2",
@@ -11170,9 +11170,9 @@
       }
     },
     "node_modules/@lblod/ember-submission-form-fields": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.13.0.tgz",
-      "integrity": "sha512-Kc5Ckl9krxDTAj6V2tGCGYABhkYhgcesvOJPVyylbImsPzaiAJ5bCXTQfFnGvddjxh/SlCI/J1bgw7GoqPazmw==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-submission-form-fields/-/ember-submission-form-fields-2.14.1.tgz",
+      "integrity": "sha512-LYJx/VslsX1ZWhUQhCOPZf0LlMugn6GP33QYw9p9r5KfjwO+vJ1uFNe1p6BjSMqbirHOd9szzESCeCuy/8WpAw==",
       "dev": true,
       "dependencies": {
         "@lblod/submission-form-helpers": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@embroider/webpack": "^3.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
-    "@lblod/ember-submission-form-fields": "^2.13.0",
+    "@lblod/ember-submission-form-fields": "^2.14.1",
     "broccoli-asset-rev": "^3.0.0",
     "codemirror": "^6.0.1",
     "codemirror-lang-turtle": "^0.0.2",

--- a/public/forms/builder/form.ttl
+++ b/public/forms/builder/form.ttl
@@ -83,7 +83,6 @@ ext:propertyGroupGenerator a form:Generator;
 ext:propertyGroupItem a form:SubForm;
   form:includes ext:propertyGroupNameF;
   form:includes ext:propertyGroupDescriptionF;
-  form:includes ext:propertyGroupOrderF;
   form:hasFieldGroup ext:propertyGroupPg.
 
 ext:propertyGroupNameF a form:Field ;
@@ -101,16 +100,6 @@ ext:propertyGroupDescriptionF a form:Field ;
   sh:order 1 ;
   sh:path form:help ;
   form:displayType displayTypes:textArea  ;
-  sh:group ext:propertyGroupPg .
-
-ext:propertyGroupOrderF a form:Field ;
-  sh:name "Order" ;
-  sh:order 2 ;
-  sh:path sh:order ;
-  form:help """
-    Order of the section, calculated from top to bottom. The bigger the number, the lower it will render.
-   """;
-  form:displayType displayTypes:numericalInput;
   sh:group ext:propertyGroupPg .
 
 ##########################################################
@@ -136,7 +125,6 @@ ext:formNodesL a form:Listing;
 ##########################################################
 ext:formNodesFormItem a form:SubForm;
   form:includes ext:formNodesNameF;
-  form:includes ext:formNodesOrderF;
   form:includes ext:formNodesTypeF;
   form:includes ext:formNodeHelpTextF;
   form:includes ext:formNodeOptionsF;
@@ -148,16 +136,6 @@ ext:formNodesNameF a form:Field ;
   sh:order 1 ;
   sh:path sh:name ;
   form:displayType displayTypes:defaultInput;
-  sh:group ext:formFieldPg .
-
-ext:formNodesOrderF a form:Field ;
-  sh:name "Field order" ;
-  sh:order 2 ;
-  sh:path sh:order ;
-  form:help """
-    Order of the field, calculated from top to bottom. The bigger the number, the lower it will render.
-   """;
-  form:displayType displayTypes:numericalInput;
   sh:group ext:formFieldPg .
 
 ext:formNodesTypeF a form:Field ;

--- a/public/forms/builder/form.ttl
+++ b/public/forms/builder/form.ttl
@@ -62,6 +62,7 @@ ext:propertyGroupL a form:Listing;
   form:addLabel "New section";
   form:canRemove true;
   form:removeLabel "Remove section";
+  form:canChangeOrder true;
   sh:group ext:mainPg;
   sh:order 1 .
 
@@ -101,7 +102,7 @@ ext:propertyGroupDescriptionF a form:Field ;
   sh:path form:help ;
   form:displayType displayTypes:textArea  ;
   sh:group ext:propertyGroupPg .
-  
+
 ext:propertyGroupOrderF a form:Field ;
   sh:name "Order" ;
   sh:order 2 ;
@@ -126,6 +127,7 @@ ext:formNodesL a form:Listing;
   form:addLabel "Add field";
   form:canRemove true;
   form:removeLabel "Remove field";
+  form:canChangeOrder true;
   sh:group ext:mainPg;
   sh:order 2 .
 
@@ -232,6 +234,7 @@ ext:formListingL a form:Listing;
   form:canAdd true;
   form:addLabel "Add new Listing";
   form:canRemove true;
+  form:canChangeOrder true;
   sh:group ext:mainPg;
   sh:order 3 .
 
@@ -245,6 +248,7 @@ ext:formListingTableL a form:Listing;
   form:canAdd true;
   form:addLabel "Add new table listing";
   form:canRemove true;
+  form:canChangeOrder true;
   sh:group ext:mainPg;
   sh:order 4 .
 
@@ -372,5 +376,6 @@ ext:subformNodesL a form:Listing;
   form:addLabel "Add new field";
   form:canRemove true;
   form:removeLabel "Remove Field";
+  form:canChangeOrder true;
   sh:group ext:listingPg;
   sh:order 60 .


### PR DESCRIPTION
This uses the new reordering feature to the builder form listings.

I didn't add it to the "validations" listing since the order there doesn't really matter _I think_?