### PR TITLE
Feat: create validation concept scheme selector

### DIFF
--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.hbs
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.hbs
@@ -1,0 +1,34 @@
+{{#unless @inTable}}
+  <AuLabel
+    @error={{this.hasErrors}}
+    @required={{this.isRequired}}
+    for={{this.inputId}}
+  >
+    {{@field.label}}
+  </AuLabel>
+{{/unless}}
+<div class={{if this.hasErrors "ember-power-select--error"}}>
+  <PowerSelect
+    @triggerId={{this.inputId}}
+    @searchField="label"
+    @searchEnabled={{this.searchEnabled}}
+    @selected={{this.selected}}
+    @options={{this.options}}
+    @onClose={{fn (mut this.hasBeenFocused) true}}
+    @onChange={{this.updateSelection}}
+    @allowClear={{true}}
+    @loadingMessage="Aan het laden..."
+    @noMatchesMessage="Geen resultaten gevonden"
+    @disabled={{@show}}
+    data-test-field-uri={{@field.uri.value}}
+    as |concept|
+  >
+    <span data-test-field-uri={{concept.subject.value}}>
+      {{concept.label}}
+    </span>
+  </PowerSelect>
+</div>
+
+{{#each this.errors as |error|}}
+  <AuHelpText @error={{true}}>{{error.resultMessage}}</AuHelpText>
+{{/each}}

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -38,7 +38,7 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
         displayType,
         this.EXT('canHaveValidation'),
         undefined,
-        graphs.metaGraph
+        graphs.fieldGraph
       )
       .map((triple) => triple.object);
   }
@@ -61,7 +61,7 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
     const conceptOptions = this.getPossibleValidationsForDisplayType(
       fieldDisplayType,
       this.args.formStore,
-      this.args.graphs.sourceGraph
+      this.args.graphs
     );
 
     const allOptions = this.args.formStore

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -1,0 +1,121 @@
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { tracked } from '@glimmer/tracking';
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import {
+  SKOS,
+  triplesForPath,
+  updateSimpleFormValue,
+} from '@lblod/submission-form-helpers';
+import { Namespace, namedNode } from 'rdflib';
+
+function byLabel(a, b) {
+  const textA = a.label.toUpperCase();
+  const textB = b.label.toUpperCase();
+  return textA < textB ? -1 : textA > textB ? 1 : 0;
+}
+
+export default class ValidationConceptSchemeSelectorComponent extends InputFieldComponent {
+  inputId = 'select-' + guidFor(this);
+
+  @tracked selected = null;
+  @tracked options = [];
+  @tracked searchEnabled = true;
+
+  EXT = new Namespace('http://mu.semte.ch/vocabularies/ext/');
+  FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
+  RDF = new Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#type');
+
+  constructor() {
+    super(...arguments);
+    this.loadOptions();
+    this.loadProvidedValue();
+  }
+
+  getPossibleValidationsForDisplayType(displayType, store, graphs) {
+    return store
+      .match(
+        displayType,
+        this.EXT('canHaveValidation'),
+        undefined,
+        graphs.metaGraph
+      )
+      .map((triple) => triple.object);
+  }
+
+  loadOptions() {
+    const fieldDisplayType = this.args.formStore.any(
+      this.EXT('formNodesNameF'),
+      this.FORM('displayType'),
+      undefined,
+      this.args.graphs.formGraph
+    );
+
+    const metaGraph = this.args.graphs.metaGraph;
+    const fieldOptions = this.args.field.options;
+    const conceptScheme = new namedNode(fieldOptions.conceptScheme);
+
+    if (fieldOptions.searchEnabled !== undefined) {
+      this.searchEnabled = fieldOptions.searchEnabled;
+    }
+    const conceptOptions = this.getPossibleValidationsForDisplayType(
+      fieldDisplayType,
+      this.args.formStore,
+      this.args.graphs.sourceGraph
+    );
+
+    const allOptions = this.args.formStore
+      .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)
+      .map((t) => {
+        const label = this.args.formStore.any(
+          t.subject,
+          SKOS('prefLabel'),
+          undefined,
+          metaGraph
+        );
+        return { subject: t.subject, label: label && label.value };
+      });
+
+    this.options = allOptions.filter((option) => {
+      return conceptOptions
+        .map((concept) => concept.value)
+        .includes(option.subject.value);
+    });
+    this.options.sort(byLabel);
+  }
+
+  loadProvidedValue() {
+    if (this.isValid) {
+      // Assumes valid input
+      // This means even though we can have multiple values for one path (e.g. rdf:type)
+      // this selector will only accept one value, and we take the first value from the matches.
+      // The validation makes sure the matching value is the sole one.
+      const matches = triplesForPath(this.storeOptions, true).values;
+      this.selected = this.options.find((opt) =>
+        matches.find((m) => m.equals(opt.subject))
+      );
+    }
+  }
+
+  @action
+  updateSelection(option) {
+    this.selected = option;
+
+    // Cleanup old value(s) in the store
+    const matches = triplesForPath(this.storeOptions, true).values;
+    const matchingOptions = matches.filter((m) =>
+      this.options.find((opt) => m.equals(opt.subject))
+    );
+    matchingOptions.forEach((m) =>
+      updateSimpleFormValue(this.storeOptions, undefined, m)
+    );
+
+    // Insert new value in the store
+    if (option) {
+      updateSimpleFormValue(this.storeOptions, option.subject);
+    }
+
+    this.hasBeenFocused = true;
+    super.updateValidations();
+  }
+}

--- a/app/routes/formbuilder/edit.js
+++ b/app/routes/formbuilder/edit.js
@@ -3,6 +3,7 @@ import template from '../../utils/basic-form-template';
 import { inject as service } from '@ember/service';
 import { registerFormFields } from '@lblod/ember-submission-form-fields';
 import PropertyGroupSelector from '../../components/rdf-form-fields/property-group-selector';
+import ValidationConceptSchemeSelectorComponent from '../../components/rdf-form-fields/validation-concept-scheme-selector';
 
 export default class FormbuilderEditRoute extends Route {
   @service store;
@@ -48,6 +49,11 @@ export default class FormbuilderEditRoute extends Route {
         displayType:
           'http://lblod.data.gift/display-types/propertyGroupSelector',
         edit: PropertyGroupSelector,
+      },
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/validationConceptSchemeSelector',
+        edit: ValidationConceptSchemeSelectorComponent,
       },
     ]);
   }

--- a/public/forms/builder/meta.ttl
+++ b/public/forms/builder/meta.ttl
@@ -15,7 +15,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "defaultInput" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/c09902d3-9421-49e9-a2e6-d3ac42abbca2> , <http://lblod.data.gift/concepts/82d71dd7-8be2-4886-acb0-5d04a31c53e9> , <http://lblod.data.gift/concepts/26a91f04-58af-480f-b25f-19c48432a0a3> , <http://lblod.data.gift/concepts/1bc4475c-7df0-46e7-9ede-a91a9bd93bd4> , <http://lblod.data.gift/concepts/60873518-5423-4121-ba6a-9635b18242a0> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/c09902d3-9421-49e9-a2e6-d3ac42abbca2> , <http://lblod.data.gift/concepts/82d71dd7-8be2-4886-acb0-5d04a31c53e9> , <http://lblod.data.gift/concepts/26a91f04-58af-480f-b25f-19c48432a0a3> , <http://lblod.data.gift/concepts/1bc4475c-7df0-46e7-9ede-a91a9bd93bd4> , <http://lblod.data.gift/vocabularies/forms/MaxLength> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "68ccebe5-84fb-4976-a9b1-28b1d3ef3687" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Input"@en .
@@ -23,7 +23,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "numericalInput" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/d19cf942-98be-4369-a883-b607d3330c5f> , <http://lblod.data.gift/concepts/50edc60f-3df1-4d49-b5e1-d86b65e8f8ec> , <http://lblod.data.gift/concepts/60873518-5423-4121-ba6a-9635b18242a0> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/d19cf942-98be-4369-a883-b607d3330c5f> , <http://lblod.data.gift/concepts/50edc60f-3df1-4d49-b5e1-d86b65e8f8ec> , <http://lblod.data.gift/vocabularies/forms/MaxLength> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "c1be61dc-4ad1-4d21-a847-17c61d64c733" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Numerical input"@en .
@@ -31,7 +31,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "date" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/4a1eb2d0-22d7-4a66-a8ca-fb54e3cfda37> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/4a1eb2d0-22d7-4a66-a8ca-fb54e3cfda37> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "4f1569e8-6ebc-4c61-9c3a-9affe7c38f28" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Date"@en .
@@ -39,7 +39,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "dateTime" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/3630e744-760a-494f-95aa-130c09649af6> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/3630e744-760a-494f-95aa-130c09649af6> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "3b2016b4-566e-47ab-83ff-46fe643b08ac" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Date and time"@en .
@@ -47,7 +47,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "dateRange" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "bcb0457e-425b-4a39-8213-1ce84b781688" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Date range"@en .
@@ -55,7 +55,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "textArea" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/concepts/60873518-5423-4121-ba6a-9635b18242a0> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> , <http://lblod.data.gift/vocabularies/forms/MaxLength> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "2e114946-3f3e-43ee-af16-d7c7255977e3" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Text area"@en .
@@ -63,7 +63,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "conceptSchemeSelector" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "true"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/2bf94470-a6d8-40c2-8295-707cc0922f1b> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/2bf94470-a6d8-40c2-8295-707cc0922f1b> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "8ad9281f-fd76-4d99-b84c-9b7ae434fb2d" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Dropdown"@en .
@@ -71,7 +71,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "files" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "be1e99bd-8c4c-4b9c-bc88-732c692ee069" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Files"@en .
@@ -79,7 +79,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "remoteUrls" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/0bded4ae-c4dd-42ee-a9b0-f2232f48b2e8> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/0bded4ae-c4dd-42ee-a9b0-f2232f48b2e8> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "e322303f-bace-4279-9267-ce8c7780dc97" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Urls"@en .
@@ -87,7 +87,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "switch" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "eabf6541-6fc3-4ac1-95b7-c9fab5f5a366" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Switch"@en .
@@ -95,7 +95,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "checkbox" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/3555ddd7-2565-4700-957d-719e84f5b002> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "32b6f216-6420-4fe5-94e9-37f0c5186550" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Checkbox"@en .
@@ -103,7 +103,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "conceptSchemeRadioButtons" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "true"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/2bf94470-a6d8-40c2-8295-707cc0922f1b> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/2bf94470-a6d8-40c2-8295-707cc0922f1b> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "9ec72078-c1ef-4126-b635-d426847af8e9" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Radio buttons"@en .
@@ -111,7 +111,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "conceptSchemeMultiSelector" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "true"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> , <http://lblod.data.gift/concepts/b06cd462-ea9e-4273-9e7a-6d5b93a43f5f> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> , <http://lblod.data.gift/concepts/b06cd462-ea9e-4273-9e7a-6d5b93a43f5f> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "ce803ee6-fb61-43f6-a2f7-22968ca9a7e6" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Multi selector"@en .
@@ -119,7 +119,7 @@ ns1:c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6  ns3:uuid  "c5a91bd7-3eb5-4d69-a51b-9ba
   rdf:type  rdfs:Class , skos:Concept ;
   <http://mu.semte.ch/vocabularies/ext/displayType>   "search" ;
   <http://mu.semte.ch/vocabularies/ext/usesConceptScheme>   "false"^^xsd:boolean ;
-  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/concepts/629bddbb-bf30-48d6-95af-c2f406bd9e8c> ;
+  <http://mu.semte.ch/vocabularies/ext/canHaveValidation>   <http://lblod.data.gift/vocabularies/forms/RequiredConstraint> ;
   <http://mu.semte.ch/vocabularies/core/uuid>   "ec03d1ee-8542-48d8-b75a-0597080b5aa6" ;
   skos:inScheme   <http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6> ;
   skos:prefLabel  "Search"@en .

--- a/public/forms/validation/form.ttl
+++ b/public/forms/validation/form.ttl
@@ -95,7 +95,7 @@ fields:validatonSelectorF a form:Field ;
         sh:path rdf:type ;
         sh:resultMessage "Dit veld is verplicht."@nl
     ] ;
-  form:displayType displayTypes:conceptSchemeSelector ;
+  form:displayType displayTypes:validationConceptSchemeSelector ;
   form:options """{"conceptScheme":"http://lblod.data.gift/concept-schemes/possibleValidations","searchEnabled":true}""" ;
   sh:group ext:formFieldPg ;
   form:hasConditionalFieldGroup fields:maxLengthValidationCFG .


### PR DESCRIPTION
Issue: [SFB-3](https://binnenland.atlassian.net/jira/software/c/projects/SFB/issues/SFB-3)

This selector will only show the validations that are possible for that display type (field).
Each field has a predicate `canHaveValidation` and the options of the dropdown are based on that