### PR TITLE
Fix: saving the form data

### DIFF
--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -48,9 +48,7 @@ export default class FormbuilderEditController extends Controller {
         isInitialRouteCall: true,
       });
 
-      if (isFormChangedSavedState) {
-        this.setFormChanged(true);
-      }
+      this.setFormChanged(isFormChangedSavedState);
     } else {
       this.deregisterFromObservable();
     }

--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -58,6 +58,7 @@ export default class FormbuilderEditController extends Controller {
       resetBuilder: false,
       isInitialRouteCall: false,
     });
+    this.formChanged = true;
   }
 
   @task({ restartable: true })

--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -40,12 +40,17 @@ export default class FormbuilderEditController extends Controller {
   @action
   async toggleIsAddingValidationToForm() {
     this.isShowBuilder = !this.isShowBuilder;
+    const isFormChangedSavedState = this.formChanged;
     if (this.isShowBuilder) {
-      this.refresh.perform({
+      await this.refresh.perform({
         formTtlCode: this.code,
         resetBuilder: false,
         isInitialRouteCall: true,
       });
+
+      if (isFormChangedSavedState) {
+        this.setFormChanged(true);
+      }
     } else {
       this.deregisterFromObservable();
     }
@@ -58,7 +63,7 @@ export default class FormbuilderEditController extends Controller {
       resetBuilder: false,
       isInitialRouteCall: false,
     });
-    this.formChanged = true;
+    this.setFormChanged(true);
   }
 
   @task({ restartable: true })


### PR DESCRIPTION
Everytime you go to the builder tab the refresh method is called with the `isInitialRouteCall` parameter on `true` this makes it that the `formChanged` variable is set to false as when initially lodaing the data there is no way that you already changed something in the form. 


I added a saved state of the variable `formChanged` to overwrite this but it feels that im hAcKinG more than we should @Windvis 