### PR TITLE
feat: directly serialize the field forms with the builder form

### DIFF
--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -171,10 +171,7 @@ export default class AddValidationsToFormComponent extends Component {
     }
 
     yield this.mergeThFieldFormsWithTheBuilderForm();
-
-    builderStore.registerObserver(() => {
-      this.updatedFormFieldValidations.perform(builderStore);
-    });
+    this.registerToObservableForStoresWithForm()
   }
 
   updateDifferencesInTriples(newTriples, oldTriples, store) {
@@ -246,8 +243,8 @@ export default class AddValidationsToFormComponent extends Component {
     }
   }
 
-  registerToObservableForStoresWithForm(storesWithForm) {
-    for (const storeWithForm of storesWithForm) {
+  registerToObservableForStoresWithForm() {
+    for (const storeWithForm of this.storesWithForm) {
       storeWithForm.store.registerObserver(async () => {
         await this.updatedFormFieldValidations.perform(storeWithForm.store);
       });


### PR DESCRIPTION
## ID
 [SFB-40]https://binnenland.atlassian.net/browse/SFB-40

 ## Description

This update does not fall directly under this issue but while checking on how it should work for the result message i got the idea that the component of the validation tab is not updated when something is changed in the field's form. Now when adding a validation the preview is directly updated.

 ## Type of change

 - [x] Improvement
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Add a validation to a field so the serialization is triggered.

 ## Links to other PR's

 - /