### PR TITLE
Fix: task throws a cancellation error when an update is done in the field forms

### DIFF
--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -74,38 +74,6 @@ export default class AddValidationsToFormComponent extends Component {
     this.args.onUpdateValidations(this.savedBuilderTtlCode);
   }
 
-<<<<<<< HEAD
-  getFieldDataForStoreWithForm(storeWithForm) {
-    const isValidTtl = areValidationsInGraphValidated(
-      storeWithForm.store,
-      this.graphs.sourceGraph
-    );
-    if (isValidTtl) {
-      const triples = getFieldAndValidationTriples(
-        storeWithForm.subject,
-        storeWithForm.store,
-        this.graphs.sourceGraph
-      );
-
-      return {
-        store: storeWithForm.store,
-        subject: storeWithForm.subject,
-        triples: triples,
-      };
-    } else {
-      showErrorToasterMessage(
-        this.toaster,
-        `Form of field with subject: ${storeWithForm.subject} is invalid.`
-      );
-      console.error(
-        `Current invalid field ttl for subject: ${storeWithForm.subject}`,
-        storeWithForm.store.serializeDataMergedGraph(this.graphs.sourceGraph)
-      );
-    }
-  }
-
-=======
->>>>>>> 5823ffb (refactor: not all field forms are merged everytime only when something is changed in the specific field form)
   getFieldDataForStoreWithForm(storeWithForm) {
     const isValidTtl = areValidationsInGraphValidated(
       storeWithForm.store,

--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -103,6 +103,35 @@ export default class AddValidationsToFormComponent extends Component {
     }
   }
 
+  getFieldDataForStoreWithForm(storeWithForm) {
+    const isValidTtl = areValidationsInGraphValidated(
+      storeWithForm.store,
+      this.graphs.sourceGraph
+    );
+    if (isValidTtl) {
+      const triples = getFieldAndValidationTriples(
+        storeWithForm.subject,
+        storeWithForm.store,
+        this.graphs.sourceGraph
+      );
+
+      return {
+        store: storeWithForm.store,
+        subject: storeWithForm.subject,
+        triples: triples,
+      };
+    } else {
+      showErrorToasterMessage(
+        this.toaster,
+        `Form of field with subject: ${storeWithForm.subject} is invalid.`
+      );
+      console.error(
+        `Current invalid field ttl for subject: ${storeWithForm.subject}`,
+        storeWithForm.store.serializeDataMergedGraph(this.graphs.sourceGraph)
+      );
+    }
+  }
+
   getFieldsData(storesWithForm) {
     const fieldsData = [];
 

--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -59,62 +59,61 @@ export default class AddValidationsToFormComponent extends Component {
     this.registerToObservableForStoresWithForm(this.storesWithForm);
   }
 
-  async mergeThFieldFormsWithTheBuilderForm() {
-    this.deregisterFromObservableForStoresWithForm(this.storesWithForm);
+  async mergeFieldDataWithBuilderForm(fieldData) {
+    const storeWithMergedField = await mergeFieldDataWithBuilderForm(
+      fieldData,
+      this.savedBuilderTtlCode,
+      this.graphs
+    );
 
-    for (const fieldData of this.getFieldsData(this.storesWithForm)) {
-      const storeWithMergedField = await mergeFieldDataWithBuilderForm(
-        fieldData,
-        this.savedBuilderTtlCode,
-        this.graphs
-      );
-
-      const sourceTtl = storeWithMergedField.serializeDataMergedGraph(
-        this.graphs.sourceGraph
-      );
-      this.savedBuilderTtlCode = sourceTtl;
-    }
+    const sourceTtl = storeWithMergedField.serializeDataMergedGraph(
+      this.graphs.sourceGraph
+    );
+    this.savedBuilderTtlCode = sourceTtl;
 
     this.args.onUpdateValidations(this.savedBuilderTtlCode);
+  }
+
+  getFieldDataForStoreWithForm(storeWithForm) {
+    const isValidTtl = areValidationsInGraphValidated(
+      storeWithForm.store,
+      this.graphs.sourceGraph
+    );
+    if (isValidTtl) {
+      const triples = getFieldAndValidationTriples(
+        storeWithForm.subject,
+        storeWithForm.store,
+        this.graphs.sourceGraph
+      );
+
+      return {
+        store: storeWithForm.store,
+        subject: storeWithForm.subject,
+        triples: triples,
+      };
+    } else {
+      showErrorToasterMessage(
+        this.toaster,
+        `Form of field with subject: ${storeWithForm.subject} is invalid.`
+      );
+      console.error(
+        `Current invalid field ttl for subject: ${storeWithForm.subject}`,
+        storeWithForm.store.serializeDataMergedGraph(this.graphs.sourceGraph)
+      );
+    }
   }
 
   getFieldsData(storesWithForm) {
     const fieldsData = [];
 
     for (const storeWithForm of storesWithForm) {
-      const isValidTtl = areValidationsInGraphValidated(
-        storeWithForm.store,
-        this.graphs.sourceGraph
-      );
-      if (isValidTtl) {
-        const triples = getFieldAndValidationTriples(
-          storeWithForm.subject,
-          storeWithForm.store,
-          this.graphs.sourceGraph
-        );
-
-        fieldsData.push({
-          store: storeWithForm.store,
-          subject: storeWithForm.subject,
-          triples: triples,
-        });
-      } else {
-        showErrorToasterMessage(
-          this.toaster,
-          `Form of field with subject: ${storeWithForm.subject} is invalid.`
-        );
-        console.error(
-          `Current invalid field ttl for subject: ${storeWithForm.subject}`,
-          storeWithForm.store.serializeDataMergedGraph(this.graphs.sourceGraph)
-        );
-      }
+      fieldsData.push(this.getFieldDataForStoreWithForm(storeWithForm));
     }
 
     return fieldsData;
   }
 
-  @task({ restartable: true })
-  *updatedFormFieldValidations(builderStore) {
+  updatedFormFieldValidations(builderStore) {
     if (
       !areValidationsInGraphValidated(builderStore, this.graphs.sourceGraph)
     ) {
@@ -170,8 +169,16 @@ export default class AddValidationsToFormComponent extends Component {
       builderStore.addAll([statement]);
     }
 
-    yield this.mergeThFieldFormsWithTheBuilderForm();
-    this.registerToObservableForStoresWithForm()
+    const storeWithForm = this.storesWithForm
+      .filter((storeWithForm) => storeWithForm.store == builderStore)
+      .shift();
+    this.mergeFieldDataWithBuilderForm(
+      this.getFieldDataForStoreWithForm(storeWithForm)
+    );
+
+    builderStore.registerObserver(() => {
+      this.updatedFormFieldValidations(builderStore);
+    });
   }
 
   updateDifferencesInTriples(newTriples, oldTriples, store) {
@@ -243,10 +250,10 @@ export default class AddValidationsToFormComponent extends Component {
     }
   }
 
-  registerToObservableForStoresWithForm() {
-    for (const storeWithForm of this.storesWithForm) {
-      storeWithForm.store.registerObserver(async () => {
-        await this.updatedFormFieldValidations.perform(storeWithForm.store);
+  registerToObservableForStoresWithForm(storesWithForm) {
+    for (const storeWithForm of storesWithForm) {
+      storeWithForm.store.registerObserver(() => {
+        this.updatedFormFieldValidations(storeWithForm.store);
       });
     }
   }

--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -74,6 +74,7 @@ export default class AddValidationsToFormComponent extends Component {
     this.args.onUpdateValidations(this.savedBuilderTtlCode);
   }
 
+<<<<<<< HEAD
   getFieldDataForStoreWithForm(storeWithForm) {
     const isValidTtl = areValidationsInGraphValidated(
       storeWithForm.store,
@@ -103,6 +104,8 @@ export default class AddValidationsToFormComponent extends Component {
     }
   }
 
+=======
+>>>>>>> 5823ffb (refactor: not all field forms are merged everytime only when something is changed in the specific field form)
   getFieldDataForStoreWithForm(storeWithForm) {
     const isValidTtl = areValidationsInGraphValidated(
       storeWithForm.store,


### PR DESCRIPTION
## ID
 [SFB-44](https://binnenland.atlassian.net/browse/SFB-44)

 ## Description

As we changed that every change in a fields validation form triggers a merging of the field form with the builderForm so the validation will be visible in the preview screen. This throwed an error because the current task for merging was cancelled. (See screenshot in the issue).

As the task is restartable previous task can be cancelled. The issue here was that we are `waiting` in the update of the field form what makes the restartable task obsolete. Removed the async await for this and this fixed the issue.

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Create a form with one field and add multiple validations to it
2. Create a form with a second field and see if the validations added to the second field are also applied 

 ## Links to other PR's

 - /