### PR TITLE
SFB-46: make the code editor workable

### DIFF
--- a/app/components/code-edit-modal.hbs
+++ b/app/components/code-edit-modal.hbs
@@ -1,13 +1,23 @@
-<AuModal
-  @modalOpen={{true}}
-  @closeModal={{@onClose}}
->
+<AuModal @modalOpen={{true}} @closeModal={{@onClose}}>
   <:title>Formulier code bewerken</:title>
   <:body>
     <div
-      {{editor @code (perform this.handleCodeChange)}}
+      {{editor this.formCode (perform this.handleCodeChange)}}
       {{!template-lint-disable no-inline-styles}}
       style="overflow: auto; height: 100%; width:100%"
     ></div>
+    <div class="au-u-text-right">
+      <AuButton
+        class="au-u-margin-left-small"
+        @skin="secondary"
+        @disabled={{this.isButtonsDisabled}}
+        {{on "click" this.restoreForm}}
+      >Reset</AuButton>
+      <AuButton
+        class="au-u-margin-left-small"
+        @disabled={{this.isButtonsDisabled}}
+        {{on "click" this.updateForm}}
+      >Bewaar</AuButton>
+    </div>
   </:body>
 </AuModal>

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -37,7 +37,6 @@ export default class CodeEditModal extends Component {
   @action
   updateForm() {
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
-    this.formCodeManager.pinLatestVersionAsReference();
 
     this.args.onCodeChange?.(this.formCode);
     this.updateButtonDisabledState();

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -29,9 +29,7 @@ export default class CodeEditModal extends Component {
 
   @action
   restoreForm() {
-    this.formCode = this.formCodeManager.getTtlOfVersion(
-      this.formCodeManager.getReferenceVersion()
-    );
+    this.formCode = this.formCodeManager.getTtlOfReferenceVersion();
     this.formCodeManager.addFormCode(this.formCode);
     this.updateButtonDisabledState();
   }
@@ -39,7 +37,7 @@ export default class CodeEditModal extends Component {
   @action
   updateForm() {
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
-    this.formCodeManager.pinLatestVersionAsReferenceTtl();
+    this.formCodeManager.pinLatestVersionAsReference();
 
     this.args.onCodeChange?.(this.formCode);
     this.updateButtonDisabledState();

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -1,9 +1,42 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { tracked } from '@glimmer/tracking';
 import { restartableTask, timeout } from 'ember-concurrency';
 
 export default class CodeEditModal extends Component {
+  @tracked formCode;
+  @tracked formCodeUpdates;
+  @tracked isButtonsDisabled;
+
+  constructor() {
+    super(...arguments);
+    this.formCode = this.args.code;
+    this.isButtonsDisabled = true;
+  }
+
   handleCodeChange = restartableTask(async (newCode) => {
-    await timeout(500);
-    this.args.onCodeChange?.(newCode);
+    if (newCode == this.formCode) {
+      this.isButtonsDisabled = true;
+      this.formCode = this.formCodeUpdates;
+
+      return;
+    }
+    this.formCodeUpdates = newCode;
+    this.isButtonsDisabled = false;
   });
+
+  @action
+  restoreForm() {
+    this.isButtonsDisabled = true;
+    this.formCode = this.args.code;
+  }
+
+  @action
+  updateForm() {
+    this.isButtonsDisabled = true;
+    this.formCode = this.formCodeUpdates;
+    console.log(`update code to `, this.formCode);
+    this.args.onCodeChange?.(this.formCode);
+    this.args.onClose(true);
+  }
 }

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -13,30 +13,40 @@ export default class CodeEditModal extends Component {
   constructor() {
     super(...arguments);
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
-    this.isButtonsDisabled = true;
+    this.updateButtonDisabledState();
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+
+    this.args.onCodeChange?.(this.formCode);
   }
 
   handleCodeChange = restartableTask(async (newCode) => {
     this.formCodeManager.addFormCode(newCode);
-
-    this.isButtonsDisabled =
-      !this.formCodeManager.isLatestDeviatingFromReference();
+    this.updateButtonDisabledState();
   });
 
   @action
   restoreForm() {
-    this.isButtonsDisabled = true;
     this.formCode = this.formCodeManager.getTtlOfVersion(
       this.formCodeManager.getReferenceVersion()
     );
+    this.formCodeManager.addFormCode(this.formCode);
+    this.updateButtonDisabledState();
   }
 
   @action
   updateForm() {
-    this.isButtonsDisabled = true;
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
     this.formCodeManager.pinLatestVersionAsReferenceTtl();
 
     this.args.onCodeChange?.(this.formCode);
+    this.updateButtonDisabledState();
+  }
+
+  updateButtonDisabledState() {
+    this.isButtonsDisabled =
+      !this.formCodeManager.isLatestDeviatingFromReference();
   }
 }

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -9,12 +9,14 @@ export default class CodeEditModal extends Component {
 
   @tracked formCode;
   @tracked formCodeUpdates;
+  @tracked editorStartFormCode;
   @tracked isButtonsDisabled;
 
   constructor() {
     super(...arguments);
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
     this.formCodeUpdates = this.formCode;
+    this.editorStartFormCode = this.formCode;
     this.isButtonsDisabled = this.formCodeManager.isTtlTheSameAsLatest(
       this.formCode
     );
@@ -43,7 +45,7 @@ export default class CodeEditModal extends Component {
 
   @action
   restoreForm() {
-    this.formCode = this.formCodeManager.getTtlOfReferenceVersion();
+    this.formCode = this.editorStartFormCode;
     this.isButtonsDisabled = true;
 
     this.args.onCodeChange?.(this.formCode);
@@ -53,6 +55,7 @@ export default class CodeEditModal extends Component {
   updateForm() {
     this.formCode = this.formCodeUpdates;
     this.formCodeManager.addFormCode(this.formCode);
+    this.editorStartFormCode = this.formCodeManager.getTtlOfLatestVersion();
 
     this.args.onCodeChange?.(this.formCode);
     this.isButtonsDisabled = true;

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
-import { TurtleLanguage } from 'codemirror-lang-turtle';
 
 export default class CodeEditModal extends Component {
   @service('form-code-manager') formCodeManager;

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -15,8 +15,9 @@ export default class CodeEditModal extends Component {
     super(...arguments);
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
     this.formCodeUpdates = this.formCode;
-    this.isButtonsDisabled =
-      !this.formCodeManager.isLatestDeviatingFromReference();
+    this.isButtonsDisabled = this.formCodeManager.isTtlTheSameAsLatest(
+      this.formCode
+    );
   }
 
   willDestroy() {

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -3,47 +3,58 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { restartableTask } from 'ember-concurrency';
+import { TurtleLanguage } from 'codemirror-lang-turtle';
 
 export default class CodeEditModal extends Component {
   @service('form-code-manager') formCodeManager;
 
   @tracked formCode;
+  @tracked formCodeUpdates;
   @tracked isButtonsDisabled;
 
   constructor() {
     super(...arguments);
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
-    this.updateButtonDisabledState();
+    this.formCodeUpdates = this.formCode;
+    this.isButtonsDisabled =
+      !this.formCodeManager.isLatestDeviatingFromReference();
   }
 
   willDestroy() {
     super.willDestroy(...arguments);
 
-    this.args.onCodeChange?.(this.formCode);
+    this.args.onCodeChange?.(this.formCodeManager.getTtlOfLatestVersion());
   }
 
   handleCodeChange = restartableTask(async (newCode) => {
-    this.formCodeManager.addFormCode(newCode);
-    this.updateButtonDisabledState();
+    if (this.formCodeManager.isTtlTheSameAsLatest(newCode)) {
+      this.isButtonsDisabled = true;
+
+      return;
+    }
+
+    // The newCode is not assigned to this.fromCode as than the editor
+    // loses focus as you are udpating the content in the editor.
+    // Keeping the changes in another variable and at the end assigning
+    // the formCode to the updated code
+    this.formCodeUpdates = newCode;
+    this.isButtonsDisabled = false;
   });
 
   @action
   restoreForm() {
     this.formCode = this.formCodeManager.getTtlOfReferenceVersion();
-    this.formCodeManager.addFormCode(this.formCode);
-    this.updateButtonDisabledState();
+    this.isButtonsDisabled = true;
+
+    this.args.onCodeChange?.(this.formCode);
   }
 
   @action
   updateForm() {
-    this.formCode = this.formCodeManager.getTtlOfLatestVersion();
+    this.formCode = this.formCodeUpdates;
+    this.formCodeManager.addFormCode(this.formCode);
 
     this.args.onCodeChange?.(this.formCode);
-    this.updateButtonDisabledState();
-  }
-
-  updateButtonDisabledState() {
-    this.isButtonsDisabled =
-      !this.formCodeManager.isLatestDeviatingFromReference();
+    this.isButtonsDisabled = true;
   }
 }

--- a/app/components/code-edit-modal.js
+++ b/app/components/code-edit-modal.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { restartableTask, timeout } from 'ember-concurrency';
+import { restartableTask } from 'ember-concurrency';
 
 export default class CodeEditModal extends Component {
   @tracked formCode;
@@ -21,6 +21,10 @@ export default class CodeEditModal extends Component {
 
       return;
     }
+    // The newCode is not assigned to this.fromCode as than the editor
+    // loses focus as you are udpating the content in the editor.
+    // Keeping the changes in another variable and at the end assigning
+    // the formCode to the updated code
     this.formCodeUpdates = newCode;
     this.isButtonsDisabled = false;
   });
@@ -35,7 +39,7 @@ export default class CodeEditModal extends Component {
   updateForm() {
     this.isButtonsDisabled = true;
     this.formCode = this.formCodeUpdates;
-    console.log(`update code to `, this.formCode);
+
     this.args.onCodeChange?.(this.formCode);
     this.args.onClose(true);
   }

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -82,7 +82,6 @@
   <CodeEditModal
     @onClose={{fn (mut this.showCodeEditModal) false}}
     @onCodeChange={{@onCodeChange}}
-    @code={{@code}}
   />
 {{/if}}
 

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -68,7 +68,7 @@ export default class ToolbarComponent extends Component {
       this.toaster.success('Formulier bijgewerkt', 'Success', {
         timeOut: 5000,
       });
-      this.formCodeManager.pinLatestVersionAsReferenceTtl();
+      this.formCodeManager.pinLatestVersionAsReference();
       this.showEditModal = false;
     } catch (err) {
       this.toaster.error('Oeps, er is iets mis gegaan', 'Error', {

--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -142,7 +142,7 @@ export default class FormbuilderEditController extends Controller {
   setup(model) {
     this.formCode = this.getFormTtlCode(model.generatedForm);
     this.formCodeManager.addFormCode(this.formCode);
-    this.formCodeManager.pinLatestVersionAsReferenceTtl();
+    this.formCodeManager.pinLatestVersionAsReference();
     this.setupForms();
   }
 

--- a/app/services/form-code-manager.js
+++ b/app/services/form-code-manager.js
@@ -4,67 +4,59 @@ export default class FormCodeManagerService extends Service {
   startVersion = -1;
 
   formCodeHistory = [];
-  version = this.startVersion; // -1 so start version is 0
+  latestVersion = this.startVersion; // -1 so start version is 0
   referenceVersion = this.startVersion;
 
-  getLatestVersion() {
-    return this.version;
-  }
-
-  getReferenceVersion() {
-    return this.referenceVersion;
-  }
-
   getTtlOfLatestVersion() {
-    return this.getTtlOfVersion(this.getLatestVersion());
+    return this.#getTtlOfVersion(this.latestVersion);
   }
 
-  getTtlOfVersion(version) {
-    if (version <= this.startVersion) {
-      throw `The lowest version available is version: 0`;
+  getTtlOfReferenceVersion() {
+    return this.#getTtlOfVersion(this.referenceVersion);
+  }
+
+  pinLatestVersionAsReference() {
+    this.referenceVersion = this.latestVersion;
+  }
+
+  addFormCode(ttl) {
+    if (this.#isTtlTheSameAsLatest(ttl)) {
+      return;
     }
-    if (version > this.getLatestVersion()) {
-      throw `The highest version available is version: ${this.getLatestVersion()}`;
+
+    this.latestVersion++;
+    this.formCodeHistory[this.latestVersion] = ttl;
+  }
+
+  isLatestDeviatingFromReference() {
+    if (this.latestVersion == this.referenceVersion) {
+      return false;
     }
 
-    return this.formCodeHistory[version];
-  }
-
-  pinLatestVersionAsReferenceTtl() {
-    this.referenceVersion = this.getLatestVersion();
-  }
-
-  getHistory() {
-    return this.formCodeHistory;
+    return !this.#isTtlTheSameAsLatest(
+      this.formCodeHistory[this.referenceVersion]
+    );
   }
 
   clearHistory() {
     this.formCodeHistory = [];
-    this.version = this.startVersion;
+    this.latestVersion = this.startVersion;
   }
 
-  addFormCode(ttl) {
-    if (this.isTtlTheSameAsLatest(ttl)) {
-      return;
-    }
-
-    this.version++;
-    this.formCodeHistory[this.version] = ttl;
-  }
-
-  isTtlTheSameAsLatest(compareTtl) {
-    const latestTtl = this.formCodeHistory[this.getLatestVersion()];
+  #isTtlTheSameAsLatest(compareTtl) {
+    const latestTtl = this.formCodeHistory[this.latestVersion];
 
     return compareTtl == latestTtl;
   }
 
-  isLatestDeviatingFromReference() {
-    if (this.getLatestVersion() == this.referenceVersion) {
-      return false;
+  #getTtlOfVersion(version) {
+    if (version <= this.startVersion) {
+      throw `The lowest version available is version: 0`;
+    }
+    if (version > this.latestVersion) {
+      throw `The highest version available is version: ${this.latestVersion}`;
     }
 
-    return !this.isTtlTheSameAsLatest(
-      this.formCodeHistory[this.referenceVersion]
-    );
+    return this.formCodeHistory[version];
   }
 }

--- a/app/services/form-code-manager.js
+++ b/app/services/form-code-manager.js
@@ -20,7 +20,7 @@ export default class FormCodeManagerService extends Service {
   }
 
   addFormCode(ttl) {
-    if (this.#isTtlTheSameAsLatest(ttl)) {
+    if (this.isTtlTheSameAsLatest(ttl)) {
       return;
     }
 
@@ -28,12 +28,18 @@ export default class FormCodeManagerService extends Service {
     this.formCodeHistory[this.latestVersion] = ttl;
   }
 
+  isTtlTheSameAsLatest(compareTtl) {
+    const latestTtl = this.formCodeHistory[this.latestVersion];
+
+    return compareTtl == latestTtl;
+  }
+
   isLatestDeviatingFromReference() {
     if (this.latestVersion == this.referenceVersion) {
       return false;
     }
 
-    return !this.#isTtlTheSameAsLatest(
+    return !this.isTtlTheSameAsLatest(
       this.formCodeHistory[this.referenceVersion]
     );
   }
@@ -41,12 +47,6 @@ export default class FormCodeManagerService extends Service {
   clearHistory() {
     this.formCodeHistory = [];
     this.latestVersion = this.startVersion;
-  }
-
-  #isTtlTheSameAsLatest(compareTtl) {
-    const latestTtl = this.formCodeHistory[this.latestVersion];
-
-    return compareTtl == latestTtl;
   }
 
   #getTtlOfVersion(version) {

--- a/app/services/form-code-manager.js
+++ b/app/services/form-code-manager.js
@@ -11,6 +11,25 @@ export default class FormCodeManagerService extends Service {
     return this.version;
   }
 
+  getReferenceVersion() {
+    return this.referenceVersion;
+  }
+
+  getTtlOfLatestVersion() {
+    return this.getTtlOfVersion(this.getLatestVersion());
+  }
+
+  getTtlOfVersion(version) {
+    if (version <= this.startVersion) {
+      throw `The lowest version available is version: 0`;
+    }
+    if (version > this.getLatestVersion()) {
+      throw `The highest version available is version: ${this.getLatestVersion()}`;
+    }
+
+    return this.formCodeHistory[version];
+  }
+
   pinLatestVersionAsReferenceTtl() {
     this.referenceVersion = this.getLatestVersion();
   }


### PR DESCRIPTION
## ID
 [SFB-46](https://binnenland.atlassian.net/browse/SFB-46)

 ## Description

Editing the code in the code editor is atm not workable. In this PR you can find that two buttons are added to reset the code to the previous state or save the current code. 

The big change here is that the code is only updated to the preview and the builder if you press the save button. 

Not a fan of:
* ~when pressing save the editor closes (this is intentionally) => cannot update the this.args.code of the component or should rerender it fully~
* ~When you go directly to the editor without changing anything the code you will see is the `basic-form-template` with the comments. But when you change something in that form, save it and than open the editor again it still shows the code that represents the output but now it is optimized by the generaters. I think this is very strange to the people using this and seeing that the code they just updated is something else.~

TODO:
* Would like to add that you cannot safe the code only reset it when the editor is returning an error.
  - the code mirror editor is not storing or passing errors to the user to display https://discuss.codemirror.net/t/how-should-i-get-the-error-message/6327, https://discuss.codemirror.net/t/showing-syntax-errors/3111/6
* ~new `basic-form-template` code? https://github.com/lblod/frontend-form-builder/pull/49#issuecomment-1782549922~
  -  ~Updated the default template here https://github.com/lblod/frontend-form-builder/pull/50~

 ## Type of change

 - [x] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Edit the code and add a change
2. Reset the code
3. Update the naming of a predicate value
4. Save the code

 ## Links to other PR's

 - [SFB-43](https://binnenland.atlassian.net/browse/SFB-43)

## Attachments:
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/ccb8f7f2-fec6-474e-b939-8af815f363ae)
