### PR TITLE
Sfb 64/improve visibility of code editor

### DIFF
--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -11,7 +11,8 @@
         <ul class="au-c-list-horizontal au-u-padding-right-tiny">
           <li class="au-c-list-horizontal__item">
             <span class="au-c-app-chrome__status">
-              Bewaard op {{or @model.modified @model.created}}
+              Bewaard op
+              {{or @model.modified @model.created}}
             </span>
           </li>
         </ul>
@@ -38,33 +39,34 @@
         <AuLink @route="codelijsten">Codelijsten</AuLink>
         <AuDropdown @title="Formulier acties" @alignment="right" role="menu">
           <AuButton
-            @skin="link" @icon="copy" role="menuitem"
+            @skin="link"
+            @icon="copy"
+            role="menuitem"
             {{on "click" (fn (mut this.showEditModal) true)}}
-            >
+          >
             Bewerk naam en beschrijving
           </AuButton>
           <AuButton
-            @skin="link" @icon="export" role="menuitem"
-            {{on 'click' this.saveLocally}}
-            >
+            @skin="link"
+            @icon="export"
+            role="menuitem"
+            {{on "click" this.saveLocally}}
+          >
             Exporteer code
           </AuButton>
           <AuButton
-            @skin="link" @icon="html" role="menuitem"
-            {{on 'click' (fn (mut this.showCodeEditModal) true)}}
+            @skin="link"
+            @icon="bin"
+            role="menuitem"
+            @alert={{true}}
+            {{on "click" (fn (mut this.showDeleteModal) true)}}
           >
-            Bewerk code
-          </AuButton>
-          <AuButton
-            @skin="link" @icon="bin" role="menuitem" @alert={{true}}
-            {{on "click" (fn (mut this.showDeleteModal) true) }}
-            >
             Naar prullenmand
           </AuButton>
         </AuDropdown>
         <AuButton
           @disabled={{not @formChanged}}
-          {{on 'click' this.updateForm}}
+          {{on "click" this.updateForm}}
         >Bewaar</AuButton>
       </Group>
     </AuToolbar>
@@ -78,18 +80,12 @@
   />
 {{/if}}
 
-{{#if this.showCodeEditModal}}
-  <CodeEditModal
-    @onClose={{fn (mut this.showCodeEditModal) false}}
-    @onCodeChange={{@onCodeChange}}
-  />
-{{/if}}
-
-
 <AuModal
   @title="Bewerk naam en beschrijving"
   @modalOpen={{this.showEditModal}}
-  @closeModal={{fn (mut this.showEditModal) false}} as |Modal| >
+  @closeModal={{fn (mut this.showEditModal) false}}
+  as |Modal|
+>
   <Modal.Body>
     <div class="au-o-grid au-o-grid--small">
       <div class="au-o-grid__item au-1-1">
@@ -115,6 +111,6 @@
     </div>
   </Modal.Body>
   <Modal.Footer>
-    <AuButton {{on 'click' this.updateForm}}>Bijwerken</AuButton>
+    <AuButton {{on "click" this.updateForm}}>Bijwerken</AuButton>
   </Modal.Footer>
 </AuModal>

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -10,8 +10,6 @@ export default class ToolbarComponent extends Component {
   @service('form-code-manager') formCodeManager;
 
   @tracked showDeleteModal = false;
-  @tracked showCodeModal = false;
-  @tracked showCodeEditModal = false;
 
   @tracked showEditModal = false;
   @tracked formLabel = this.args.model.label;

--- a/app/controllers/formbuilder/edit/builder.js
+++ b/app/controllers/formbuilder/edit/builder.js
@@ -76,7 +76,6 @@ export default class FormbuilderEditBuilderController extends Controller {
     // Ideally the RdfForm component would do the right thing when the formStore
     // and form arguments change, but we're not there yet.
     await timeout(1);
-    // check if the form has changed here
     this.previewStore = new ForkingStore();
     this.previewStore.parse(
       this.formCodeManager.getTtlOfLatestVersion(),

--- a/app/controllers/formbuilder/edit/code.js
+++ b/app/controllers/formbuilder/edit/code.js
@@ -8,29 +8,48 @@ import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { FORM, RDF } from '../../../utils/rdflib';
 import { PREVIEW_SOURCE_NODE } from '../edit';
 
-export default class FormbuilderEditValidationsController extends Controller {
+export default class FormbuilderEditCodeController extends Controller {
   @service('form-code-manager') formCodeManager;
+
+  @tracked formCode;
+  @tracked formCodeUpdates;
 
   @tracked previewStore;
   @tracked previewForm;
 
   sourceNode = PREVIEW_SOURCE_NODE;
 
-  @action
-  handleCodeChange(ttlCode) {
-    this.formCodeManager.addFormCode(ttlCode);
-    this.setupPreviewForm.perform();
-    this.model.handleCodeChange();
+  constructor() {
+    super(...arguments);
   }
 
-  setupPreviewForm = restartableTask(async () => {
+  setup() {
+    this.formCode = this.model.formCode;
+    this.formCodeUpdates = this.model.formCode;
+    this.setupPreviewForm.perform(this.model.formCode);
+  }
+
+  handleCodeChange = restartableTask(async (newCode) => {
+    if (this.formCodeManager.isTtlTheSameAsLatest(newCode)) {
+      return;
+    }
+
+    // The newCode is not assigned to this.fromCode as than the editor
+    // loses focus as you are udpating the content in the editor.
+    // Keeping the changes in another variable and at the end assigning
+    // the formCode to the updated code
+    this.formCodeUpdates = newCode;
+    this.setupPreviewForm.perform(this.formCodeUpdates);
+  });
+
+  setupPreviewForm = restartableTask(async (ttlCode) => {
     // force a component recreation by unrendering it very briefly
     // Ideally the RdfForm component would do the right thing when the formStore
     // and form arguments change, but we're not there yet.
     await timeout(1);
     this.previewStore = new ForkingStore();
     this.previewStore.parse(
-      this.formCodeManager.getTtlOfLatestVersion(),
+      ttlCode,
       this.model.graphs.formGraph,
       'text/turtle'
     );
@@ -41,9 +60,6 @@ export default class FormbuilderEditValidationsController extends Controller {
       FORM('Form'),
       this.model.graphs.formGraph
     );
+    this.model.handleCodeChange(ttlCode);
   });
-
-  setup() {
-    this.setupPreviewForm.perform();
-  }
 }

--- a/app/router.js
+++ b/app/router.js
@@ -14,6 +14,7 @@ Router.map(function () {
   this.route('formbuilder', function () {
     this.route('new');
     this.route('edit', { path: '/:id/edit' }, function () {
+      this.route('code');
       this.route('builder');
       this.route('validations');
     });

--- a/app/routes/formbuilder/edit/code.js
+++ b/app/routes/formbuilder/edit/code.js
@@ -1,0 +1,38 @@
+import Route from '@ember/routing/route';
+
+import { inject as service } from '@ember/service';
+
+export default class FormbuilderEditCodeRoute extends Route {
+  @service('form-code-manager') formCodeManager;
+  @service router;
+
+  constructor() {
+    super(...arguments);
+  }
+
+  async model() {
+    const editRoute = this.modelFor('formbuilder.edit');
+    /* eslint ember/no-controller-access-in-routes: "warn" */
+    const editController = this.controllerFor('formbuilder.edit');
+    let ttlCode = null;
+
+    try {
+      ttlCode = this.formCodeManager.getTtlOfLatestVersion();
+    } catch (error) {
+      console.error(`Catched: ` + error);
+      this.router.transitionTo('formbuilder.edit.builder');
+    }
+
+    return {
+      formCode: ttlCode,
+      graphs: editRoute.graphs,
+      handleCodeChange: editController.handleCodeChange,
+    };
+  }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+
+    controller.setup();
+  }
+}

--- a/app/templates/formbuilder/edit.hbs
+++ b/app/templates/formbuilder/edit.hbs
@@ -15,6 +15,9 @@
     as |Tab|
   >
     <Tab>
+      <AuLink @route="formbuilder.edit.code" @icon="html">Code</AuLink>
+    </Tab>
+    <Tab>
       <AuLink
         @route="formbuilder.edit.builder"
         @icon="document"

--- a/app/templates/formbuilder/edit/code.hbs
+++ b/app/templates/formbuilder/edit/code.hbs
@@ -1,0 +1,23 @@
+<div class="formBuilderEdit">
+  <div
+    {{editor this.formCode (perform this.handleCodeChange)}}
+    {{!template-lint-disable no-inline-styles}}
+    style="overflow: auto; height: 100%; width:100%"
+  > </div>
+
+  <div class="formBuilderEdit__preview au-u-padding-small">
+    {{#if this.setupPreviewForm.isRunning}}
+      <AuLoader />
+    {{else}}
+      <RdfForm
+        @groupClass="au-u-margin-left-small au-u-margin-top"
+        @form={{this.previewForm}}
+        @graphs={{this.model.graphs}}
+        @formStore={{this.previewStore}}
+        @forceShowErrors={{false}}
+        @useNewListingLayout={{true}}
+        @sourceNode={{this.sourceNode}}
+      />
+    {{/if}}
+  </div>
+</div>

--- a/app/utils/basic-form-template.js
+++ b/app/utils/basic-form-template.js
@@ -9,7 +9,7 @@ nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
     a form:Field;
     form:displayType displayTypes:defaultInput;
     sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
-    sh:name "Text field";
+    sh:name "Field name";
     sh:order 2;
     sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
 nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1

--- a/app/utils/get-triples-per-field-in-store.js
+++ b/app/utils/get-triples-per-field-in-store.js
@@ -41,7 +41,7 @@ export function getFieldsInStore(store, graph) {
       fieldTriples.push(...validationTriples);
     }
 
-    let fieldName = 'Text field';
+    let fieldName = 'Field name';
     const fieldNameTriple = fieldTriples.find(
       (triple) => triple.predicate.value == SH('name').value
     );


### PR DESCRIPTION
## ID
 [SFB-64](https://binnenland.atlassian.net/browse/SFB-64)

 ## Description

When you want to edit the ttl code directly you had to go to the toolbar and select edit code. As discussed we want this to be in a tab next to the builder and the validations so it is more accessible for the developers.

 ## Type of change

 - [x] Improvement
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Look if the option is in the toolbar

 ## Links to other PR's

 - http://github.com/PR/2314135