### PR TITLE
SFB-82: Duplicate preview form in each route template

### DIFF
--- a/app/controllers/formbuilder/edit/code.js
+++ b/app/controllers/formbuilder/edit/code.js
@@ -1,11 +1,8 @@
 import Controller from '@ember/controller';
 
 import { inject as service } from '@ember/service';
-import { restartableTask, timeout } from 'ember-concurrency';
+import { restartableTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { FORM, RDF } from '../../../utils/rdflib';
-import { PREVIEW_SOURCE_NODE } from '../edit';
 
 export default class FormbuilderEditCodeController extends Controller {
   @service('form-code-manager') formCodeManager;
@@ -13,19 +10,10 @@ export default class FormbuilderEditCodeController extends Controller {
   @tracked formCode;
   @tracked formCodeUpdates;
 
-  @tracked previewStore;
-  @tracked previewForm;
-
-  sourceNode = PREVIEW_SOURCE_NODE;
-
-  constructor() {
-    super(...arguments);
-  }
-
   setup() {
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
     this.formCodeUpdates = this.formCode;
-    this.setupPreviewForm.perform(this.formCode);
+    this.model.handleCodeChange(this.formCode);
   }
 
   handleCodeChange = restartableTask(async (newCode) => {
@@ -38,27 +26,6 @@ export default class FormbuilderEditCodeController extends Controller {
     // Keeping the changes in another variable and at the end assigning
     // the formCode to the updated code
     this.formCodeUpdates = newCode;
-    this.setupPreviewForm.perform(this.formCodeUpdates);
-  });
-
-  setupPreviewForm = restartableTask(async (ttlCode) => {
-    // force a component recreation by unrendering it very briefly
-    // Ideally the RdfForm component would do the right thing when the formStore
-    // and form arguments change, but we're not there yet.
-    await timeout(1);
-    this.previewStore = new ForkingStore();
-    this.previewStore.parse(
-      ttlCode,
-      this.model.graphs.formGraph,
-      'text/turtle'
-    );
-
-    this.previewForm = this.previewStore.any(
-      undefined,
-      RDF('type'),
-      FORM('Form'),
-      this.model.graphs.formGraph
-    );
-    this.model.handleCodeChange(ttlCode);
+    this.model.handleCodeChange(this.formCodeUpdates);
   });
 }

--- a/app/controllers/formbuilder/edit/validations.js
+++ b/app/controllers/formbuilder/edit/validations.js
@@ -2,51 +2,21 @@ import Controller from '@ember/controller';
 
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { restartableTask, timeout } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
-import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { FORM, RDF } from '../../../utils/rdflib';
-import { PREVIEW_SOURCE_NODE } from '../edit';
 
 export default class FormbuilderEditValidationsController extends Controller {
   @service('form-code-manager') formCodeManager;
 
-  @tracked previewStore;
-  @tracked previewForm;
-
   @tracked formCode;
-
-  sourceNode = PREVIEW_SOURCE_NODE;
 
   @action
   handleCodeChange(ttlCode) {
     this.formCodeManager.addFormCode(ttlCode);
-    this.setup();
-    this.model.handleCodeChange();
+    this.model.handleCodeChange(ttlCode);
   }
-
-  setupPreviewForm = restartableTask(async () => {
-    // force a component recreation by unrendering it very briefly
-    // Ideally the RdfForm component would do the right thing when the formStore
-    // and form arguments change, but we're not there yet.
-    await timeout(1);
-    this.previewStore = new ForkingStore();
-    this.previewStore.parse(
-      this.formCode,
-      this.model.graphs.formGraph,
-      'text/turtle'
-    );
-
-    this.previewForm = this.previewStore.any(
-      undefined,
-      RDF('type'),
-      FORM('Form'),
-      this.model.graphs.formGraph
-    );
-  });
 
   setup() {
     this.formCode = this.formCodeManager.getTtlOfLatestVersion();
-    this.setupPreviewForm.perform();
+    this.model.handleCodeChange(this.formCode);
   }
 }

--- a/app/routes/formbuilder/edit/builder.js
+++ b/app/routes/formbuilder/edit/builder.js
@@ -1,10 +1,6 @@
 import Route from '@ember/routing/route';
 
 export default class FormbuilderEditBuilderRoute extends Route {
-  constructor() {
-    super(...arguments);
-  }
-
   async model() {
     const editRoute = this.modelFor('formbuilder.edit');
     /* eslint ember/no-controller-access-in-routes: "warn" */

--- a/app/routes/formbuilder/edit/code.js
+++ b/app/routes/formbuilder/edit/code.js
@@ -1,10 +1,6 @@
 import Route from '@ember/routing/route';
 
 export default class FormbuilderEditCodeRoute extends Route {
-  constructor() {
-    super(...arguments);
-  }
-
   async model() {
     const editRoute = this.modelFor('formbuilder.edit');
     /* eslint ember/no-controller-access-in-routes: "warn" */

--- a/app/templates/formbuilder/edit.hbs
+++ b/app/templates/formbuilder/edit.hbs
@@ -28,5 +28,26 @@
 </AuTabs>
 
 <AuBodyContainer>
-  {{outlet}}
+  <div class="formBuilderEdit">
+    {{outlet}}
+    <div class="formBuilderEdit__preview au-u-padding-small">
+      {{#if (and this.previewStore this.previewForm)}}
+        {{#if this.setupPreviewForm.isRunning}}
+          <AuLoader />
+        {{else}}
+          <RdfForm
+            @groupClass="au-u-margin-left-small au-u-margin-top"
+            @form={{this.previewForm}}
+            @graphs={{this.model.graphs}}
+            @formStore={{this.previewStore}}
+            @forceShowErrors={{false}}
+            @useNewListingLayout={{true}}
+            @sourceNode={{this.sourceNode}}
+          />
+        {{/if}}
+      {{else}}
+        <AuLoader />
+      {{/if}}
+    </div>
+  </div>
 </AuBodyContainer>

--- a/app/templates/formbuilder/edit/builder.hbs
+++ b/app/templates/formbuilder/edit/builder.hbs
@@ -1,35 +1,17 @@
 {{page-title "Builder"}}
 
-<div class="formBuilderEdit">
-  <div class="formBuilderEdit__builder au-u-padding-small">
-    {{#if (and this.builderStore this.builderForm)}}
-      <RdfForm
-        @groupClass="au-o-grid__item"
-        @form={{this.builderForm}}
-        @graphs={{this.model.graphs}}
-        @formStore={{this.builderStore}}
-        @forceShowErrors={{false}}
-        @useNewListingLayout={{true}}
-        @sourceNode={{this.previewForm}}
-      />
-    {{else}}
-      <AuLoader />
-    {{/if}}
-  </div>
-
-  <div class="formBuilderEdit__preview au-u-padding-small">
-    {{#if this.setupPreviewForm.isRunning}}
-      <AuLoader />
-    {{else}}
-      <RdfForm
-        @groupClass="au-u-margin-left-small au-u-margin-top"
-        @form={{this.previewForm}}
-        @graphs={{this.model.graphs}}
-        @formStore={{this.previewStore}}
-        @forceShowErrors={{false}}
-        @useNewListingLayout={{true}}
-        @sourceNode={{this.sourceNode}}
-      />
-    {{/if}}
-  </div>
+<div class="formBuilderEdit__builder au-u-padding-small">
+  {{#if (and this.builderStore this.builderForm)}}
+    <RdfForm
+      @groupClass="au-o-grid__item"
+      @form={{this.builderForm}}
+      @graphs={{this.model.graphs}}
+      @formStore={{this.builderStore}}
+      @forceShowErrors={{false}}
+      @useNewListingLayout={{true}}
+      @sourceNode={{this.previewForm}}
+    />
+  {{else}}
+    <AuLoader />
+  {{/if}}
 </div>

--- a/app/templates/formbuilder/edit/code.hbs
+++ b/app/templates/formbuilder/edit/code.hbs
@@ -1,25 +1,7 @@
 {{page-title "Code editor"}}
 
-<div class="formBuilderEdit">
-  <div
-    {{editor this.formCode (perform this.handleCodeChange)}}
-    {{!template-lint-disable no-inline-styles}}
-    style="overflow: auto; height: 100%; width:100%"
-  > </div>
-
-  <div class="formBuilderEdit__preview au-u-padding-small">
-    {{#if this.setupPreviewForm.isRunning}}
-      <AuLoader />
-    {{else}}
-      <RdfForm
-        @groupClass="au-u-margin-left-small au-u-margin-top"
-        @form={{this.previewForm}}
-        @graphs={{this.model.graphs}}
-        @formStore={{this.previewStore}}
-        @forceShowErrors={{false}}
-        @useNewListingLayout={{true}}
-        @sourceNode={{this.sourceNode}}
-      />
-    {{/if}}
-  </div>
-</div>
+<div
+  {{editor this.formCode (perform this.handleCodeChange)}}
+  {{!template-lint-disable no-inline-styles}}
+  style="overflow: auto; height: 100%; width:100%"
+> </div>

--- a/app/templates/formbuilder/edit/validations.hbs
+++ b/app/templates/formbuilder/edit/validations.hbs
@@ -1,31 +1,13 @@
 {{page-title "Validations"}}
 
-<div class="formBuilderEdit">
-  <div class="formBuilderEdit__builder au-u-padding-small">
-    {{#if this.formCode}}
-      <AddValidationsToForm
-        @builderTtlCode={{this.formCode}}
-        @sourceNode={{@model.form}}
-        @onNewBuilderForm={{this.handleCodeChange}}
-      />
-    {{else}}
-      <AuLoader />
-    {{/if}}
-  </div>
-
-  <div class="formBuilderEdit__preview au-u-padding-small">
-    {{#if this.setupPreviewForm.isRunning}}
-      <AuLoader />
-    {{else}}
-      <RdfForm
-        @groupClass="au-u-margin-left-small au-u-margin-top"
-        @form={{this.previewForm}}
-        @graphs={{this.model.graphs}}
-        @formStore={{this.previewStore}}
-        @forceShowErrors={{false}}
-        @useNewListingLayout={{true}}
-        @sourceNode={{this.sourceNode}}
-      />
-    {{/if}}
-  </div>
+<div class="formBuilderEdit__builder au-u-padding-small">
+  {{#if this.formCode}}
+    <AddValidationsToForm
+      @builderTtlCode={{this.formCode}}
+      @sourceNode={{@model.form}}
+      @onNewBuilderForm={{this.handleCodeChange}}
+    />
+  {{else}}
+    <AuLoader />
+  {{/if}}
 </div>


### PR DESCRIPTION
## ID
 [SFB-82](https://binnenland.atlassian.net/browse/SFB-82)

 ## Description

In the navigation at the top are three routes defined. Each route has ts own preview rdf-form and this should'nt be the case. We will be moving this rdf-form to the parent `edit` template so it is common and we do not have duplicate code that will render the preview form.

 ## Type of change

 - [x] Refactor
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Everything should work as before. In the code there should only be one `rdf-form` with a `previewStore`

 ## Links to other PR's

 - /