### PR TITLE
SFB-88: Validations cannot be edited of V2 form 

### DIFF
--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -48,8 +48,13 @@ export default class AddValidationsToFormComponent extends Component {
     this.builderStore = new ForkingStore();
     yield parseStoreGraphs(this.builderStore, ttlCode);
 
-    this.fields = yield this.createSeparateStorePerField(this.builderStore);
-    this.fields.length >= 1 ? (this.selectedField = this.fields[0]) : null;
+    this.fields = this.createFieldArray(this.builderStore);
+    this.fields.length >= 1
+      ? this.setSelectedField({
+          name: this.fields[0].name,
+          subject: this.fields[0].subject,
+        })
+      : null;
   }
 
   @action
@@ -96,24 +101,15 @@ export default class AddValidationsToFormComponent extends Component {
     }
   }
 
-  async createSeparateStorePerField(store) {
+  createFieldArray(store) {
     const fieldsData = getFieldsInStore(store, this.graphs.sourceGraph);
     const fields = [];
 
     for (const field of fieldsData) {
-      const fieldData = await createStoreForFieldData(
-        field,
-        this.savedBuilderTtlCode,
-        this.graphs
-      );
-
-      addValidationTriplesToFormNodesL(
-        fieldData.subject,
-        fieldData.store,
-        this.graphs
-      );
-
-      fields.push(fieldData);
+      fields.push({
+        name: field.name,
+        subject: field.subject,
+      });
     }
 
     return fields;

--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -25,6 +25,7 @@ export default class AddValidationsToFormComponent extends Component {
 
   builderStore;
   savedBuilderTtlCode;
+  allFields;
 
   graphs = validationGraphs;
 
@@ -59,6 +60,7 @@ export default class AddValidationsToFormComponent extends Component {
 
   @action
   async setSelectedField(field) {
+    this.fields = this.allFields;
     this.selectedField = null;
     const fieldData = await createStoreForFieldData(
       createFieldDataForSubject(field.subject, {
@@ -76,6 +78,9 @@ export default class AddValidationsToFormComponent extends Component {
     );
 
     this.selectedField = fieldData;
+    this.fields = this.fields.filter(
+      (fieldInList) => fieldInList.name !== this.selectedField.name
+    );
   }
 
   @action
@@ -111,6 +116,8 @@ export default class AddValidationsToFormComponent extends Component {
         subject: field.subject,
       });
     }
+
+    this.allFields = fields;
 
     return fields;
   }

--- a/app/components/field-validations-form.js
+++ b/app/components/field-validations-form.js
@@ -95,6 +95,13 @@ export default class FieldValidationsFormComponent extends Component {
       validationsToRemove.push(statement);
     }
 
+    applyStore.removeMatches(
+      EXT('formNodesL'),
+      FORM('validations'),
+      undefined,
+      this.graphs.sourceGraph
+    );
+
     applyStore.removeStatements(validationsToRemove);
     applyStore.addAll(validationsToApply);
 

--- a/app/utils/validation/add-field-valdiations-to-formNodesL.js
+++ b/app/utils/validation/add-field-valdiations-to-formNodesL.js
@@ -1,9 +1,7 @@
 import { Statement } from 'rdflib';
-import {
-  getTriplesWithNodeAsSubject,
-  getValidationSubjectsOnNode,
-} from '../forking-store-helpers';
+import { getValidationSubjectsOnNode } from '../forking-store-helpers';
 import { EXT, FORM } from '../rdflib';
+import { createBlankNodeForValidation } from './create-blankNode-for-validation';
 
 export function addValidationTriplesToFormNodesL(fieldSubject, store, graphs) {
   const validationSubjects = getValidationSubjectsOnNode(
@@ -11,27 +9,19 @@ export function addValidationTriplesToFormNodesL(fieldSubject, store, graphs) {
     store,
     graphs.sourceGraph
   );
+
   for (const subject of validationSubjects) {
-    const validationTriples = getTriplesWithNodeAsSubject(
+    const validation = createBlankNodeForValidation(
       subject,
       store,
-      graphs.sourceBuilderGraph
+      graphs.sourceGraph
     );
-
-    if (validationTriples.length >= 1) {
-      const formNodesLWithValidation = new Statement(
-        EXT('formNodesL'),
-        FORM('validations'),
-        subject,
-        graphs.sourceGraph
-      );
-      store.addAll([
-        formNodesLWithValidation,
-        ...validationTriples.map((triple) => {
-          triple.graph = graphs.sourceGraph;
-          return triple;
-        }),
-      ]);
-    }
+    const formNodesLWithValidation = new Statement(
+      EXT('formNodesL'),
+      FORM('validations'),
+      validation.node,
+      graphs.sourceGraph
+    );
+    store.addAll([formNodesLWithValidation, ...validation.statements]);
   }
 }

--- a/app/utils/validation/add-field-valdiations-to-formNodesL.js
+++ b/app/utils/validation/add-field-valdiations-to-formNodesL.js
@@ -1,4 +1,4 @@
-import { triple } from 'rdflib';
+import { Statement } from 'rdflib';
 import {
   getTriplesWithNodeAsSubject,
   getValidationSubjectsOnNode,
@@ -17,11 +17,12 @@ export function addValidationTriplesToFormNodesL(fieldSubject, store, graphs) {
       store,
       graphs.sourceBuilderGraph
     );
+
     if (validationTriples.length >= 1) {
-      const formNodesLWithValidation = triple(
+      const formNodesLWithValidation = new Statement(
         EXT('formNodesL'),
         FORM('validations'),
-        validationTriples[0].subject,
+        subject,
         graphs.sourceGraph
       );
       store.addAll([

--- a/app/utils/validation/create-blankNode-for-validation.js
+++ b/app/utils/validation/create-blankNode-for-validation.js
@@ -1,0 +1,20 @@
+import { BlankNode, Statement } from 'rdflib';
+import { getTriplesWithNodeAsSubject } from '../forking-store-helpers';
+
+export function createBlankNodeForValidation(validationNode, store, graph) {
+  const blankNode = new BlankNode();
+  const triples = getTriplesWithNodeAsSubject(validationNode, store, graph);
+
+  const blankNodeStatements = [];
+  for (const triple of triples) {
+    const statement = new Statement(
+      blankNode,
+      triple.predicate,
+      triple.object,
+      graph
+    );
+    blankNodeStatements.push(statement);
+  }
+
+  return { node: blankNode, statements: blankNodeStatements };
+}


### PR DESCRIPTION
## ID
[SFB-88](https://binnenland.atlassian.net/browse/SFB-88)

 ## Description

 The `form-builder` adds validations as separate nodes to the `ttl code` and manipulates that code. But V2 forms are using `blank node`  what the `form-builder` does not understand.  The overal use of validations is in `blank nodes` so in this PR I ''ll be updating the code that the validations will be added and  updated not as `named nodes` but as `blank nodes`

 ## Type of change

 - [x] Bug fix
 - [x] New feature
 - [x] Breaking change
 - [ ] Other

 ## How to test

Add and remove validations on a field. Switch fields and see if the validations are only applied to the specific field. Check the outcome `ttl code` in the editor. Than update the code in the `editor` and see if the change is applied to the `builder` and `validations` tab

 ## Links to other PR's

 - /