### PR TITLE
SFB-93: make the country code mandatory to fill in

### DIFF
--- a/app/components/rdf-form-fields/country-code-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/country-code-concept-scheme-selector.js
@@ -4,7 +4,7 @@ import { tracked } from '@glimmer/tracking';
 import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
 import { SKOS, updateSimpleFormValue } from '@lblod/submission-form-helpers';
 import { Statement, namedNode } from 'rdflib';
-import { EXT, FORM } from '../../utils/rdflib';
+import { FORM } from '../../utils/rdflib';
 import { getPrefLabelOfNode } from '../../utils/forking-store-helpers';
 
 function byLabel(a, b) {
@@ -12,11 +12,6 @@ function byLabel(a, b) {
   const textB = b.label.toUpperCase();
   return textA < textB ? -1 : textA > textB ? 1 : 0;
 }
-
-export const defaultCountryCode = {
-  label: 'BE',
-  subject: EXT('countryCodeBE'),
-};
 
 export default class CountryCodeConceptSchemeSelectorComponent extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
@@ -28,7 +23,7 @@ export default class CountryCodeConceptSchemeSelectorComponent extends InputFiel
   constructor() {
     super(...arguments);
     this.loadOptions();
-    this.loadSelectedOrDefaultCountryCodeOption();
+    this.loadSelectedCountryCodeOption();
   }
 
   loadOptions() {
@@ -54,20 +49,18 @@ export default class CountryCodeConceptSchemeSelectorComponent extends InputFiel
     this.countryCodeOptions.sort(byLabel);
   }
 
-  loadSelectedOrDefaultCountryCodeOption() {
-    const currentDefaultCountry = this.storeOptions.store.any(
+  loadSelectedCountryCodeOption() {
+    const selectedDefaultCountry = this.storeOptions.store.any(
       this.storeOptions.sourceNode,
       FORM('defaultCountry'),
       undefined,
       this.storeOptions.sourceGraph
     );
 
-    if (currentDefaultCountry) {
+    if (selectedDefaultCountry) {
       this.selectedCountryCode = this.countryCodeOptions.find(
-        (opt) => currentDefaultCountry.value == opt.label
+        (opt) => selectedDefaultCountry.value == opt.label
       );
-    } else {
-      this.selectedCountryCode = defaultCountryCode;
     }
   }
 

--- a/app/utils/validation/are-validations-in-graph-validated.js
+++ b/app/utils/validation/are-validations-in-graph-validated.js
@@ -1,6 +1,4 @@
-import { Statement } from 'rdflib';
 import { FORM } from '../rdflib';
-import { defaultCountryCode } from '../../components/rdf-form-fields/country-code-concept-scheme-selector';
 import { isMaxCharacterValueAddedToMaxLengthValidation } from './shape-validators/is-max-character-value-added';
 import { isDefaultCountryCodeAddedToValidPhoneNumber } from './shape-validators/is-country-code-added';
 import { isExactValueAddedToExactValueConstraint } from './shape-validators/is-exact-value-added';
@@ -8,22 +6,12 @@ import { isRdfTypeInSubjects } from './shape-validators/is-rdf-type-in-subjects'
 
 export function areValidationsInGraphValidated(store, graph) {
   const validationNodes = getAllValidationNodesInGraph(store, graph);
-  const defaultCountryCodesAdded = isDefaultCountryCodeAddedToValidPhoneNumber(
-    store,
-    graph
-  );
-  if (!defaultCountryCodesAdded.isAdded) {
-    const defaultCountryCodeStatements =
-      defaultCountryCodesAdded.subjectsToAddDefaultTo.map((subject) => {
-        return createDefaultCountryCodeStatement(subject, graph);
-      });
-    store.addAll(defaultCountryCodeStatements);
-  }
 
   return ![
     isRdfTypeInSubjects(validationNodes, store, graph),
     isMaxCharacterValueAddedToMaxLengthValidation(store, graph),
     isExactValueAddedToExactValueConstraint(store, graph),
+    isDefaultCountryCodeAddedToValidPhoneNumber(store, graph),
   ].includes(false);
 }
 
@@ -35,13 +23,4 @@ function getAllValidationNodesInGraph(store, graph) {
     graph
   );
   return subjectThatHaveValidations.map((statement) => statement.object);
-}
-
-function createDefaultCountryCodeStatement(subject, graph) {
-  return new Statement(
-    subject,
-    FORM('defaultCountry'),
-    defaultCountryCode.label,
-    graph
-  );
 }

--- a/app/utils/validation/shape-validators/is-country-code-added.js
+++ b/app/utils/validation/shape-validators/is-country-code-added.js
@@ -8,7 +8,6 @@ export function isDefaultCountryCodeAddedToValidPhoneNumber(store, graph) {
     graph
   );
 
-  const subjectsToAddDefaultTo = [];
   for (const triple of validPhoneNumber) {
     const countryCodeValues = store.match(
       triple.subject,
@@ -18,12 +17,9 @@ export function isDefaultCountryCodeAddedToValidPhoneNumber(store, graph) {
     );
 
     if (!countryCodeValues.length >= 1) {
-      subjectsToAddDefaultTo.push(triple.subject);
+      return false;
     }
   }
 
-  return {
-    isAdded: subjectsToAddDefaultTo.length == 0,
-    subjectsToAddDefaultTo: subjectsToAddDefaultTo,
-  };
+  return true;
 }

--- a/public/forms/validation/form.ttl
+++ b/public/forms/validation/form.ttl
@@ -87,7 +87,7 @@ fields:validatonSelectorF a form:Field ;
   sh:order 2 ;
   form:help """
    """;
-  form:validations 
+  form:validations
     [ a form:RequiredConstraint ;
         form:grouping form:Bag ;
         sh:path rdf:type ;
@@ -174,7 +174,7 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
       sh:name "Max characters" ;
       sh:order 101 ;
       sh:path form:max ;
-      form:validations 
+      form:validations
         [ a form:RequiredConstraint ;
             form:grouping form:Bag ;
             sh:path form:max ;
@@ -187,7 +187,7 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
         ] ;
       form:displayType displayTypes:defaultInput ;
       sh:group ext:formFieldPg .
-    
+
     ##########################################################
     #  Exact value field
     ##########################################################
@@ -195,7 +195,7 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
       sh:name "Exact value" ;
       sh:order 102 ;
       sh:path form:customValue ;
-      form:validations 
+      form:validations
         [ a form:RequiredConstraint ;
             form:grouping form:Bag ;
             sh:path form:customValue ;
@@ -203,7 +203,7 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
         ] ;
       form:displayType displayTypes:defaultInput ;
       sh:group ext:formFieldPg .
-   
+
     ##########################################################
     #  Phone number: country code field
     ##########################################################
@@ -211,6 +211,12 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
       sh:name "CountryCode" ;
       sh:order 103 ;
       sh:path form:defaultCountry ;
+      form:validations
+        [ a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:path form:defaultCountry ;
+            sh:resultMessage "Dit veld is verplicht."@nl
+        ] ;
       form:displayType displayTypes:countryCodeConceptSchemeSelector ;
       form:options """{"conceptScheme":"http://lblod.data.gift/concept-schemes/countryCodes","searchEnabled":true}""" ;
       sh:group ext:formFieldPg .


### PR DESCRIPTION
## ID
 [SFB-93](https://binnenland.atlassian.net/browse/SFB-93)

 ## Description

When adding the phone number validation to a field it was not fully applied to that field. This is because the component sets the default value when none is selected but this is never added to the store when you do not change this value. When you do change the value with the dropdown the validation was added.

The missing part `form:defaultCountry "BE"` was not in the triples of the validation. Now the dropdown is required and checked before applying that change.

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Add a field to the form and apply the phone number validation to it. 

1. Do not select a country code and leave
2. Select a country code and leave
3. See result

 ## Links to other PR's

 - /