### PR TITLE
fix duplicate listings by adding a class to the regular listing

### DIFF
--- a/public/forms/builder/form.ttl
+++ b/public/forms/builder/form.ttl
@@ -192,13 +192,23 @@ ext:formNodesGenerator a form:Generator;
 ##########################################################
 #  listing-scope:
 ##########################################################
+ext:formListingTableS a form:Scope;
+  sh:path form:includes;
+  form:constraint [
+     a sh:NodeShape ;
+     sh:property [
+       sh:path rdf:type ;
+       sh:targetNode form:ListingTable
+     ];
+  ].
+
 ext:formListingS a form:Scope;
   sh:path form:includes;
   form:constraint [
      a sh:NodeShape ;
      sh:property [
        sh:path rdf:type ;
-       sh:targetNode form:Listing
+       sh:targetNode form:ListingBasic
      ];
   ].
 
@@ -221,7 +231,7 @@ ext:formListingL a form:Listing;
 ##########################################################
 ext:formListingTableL a form:Listing;
   form:each ext:formListingFormItem;
-  form:scope ext:formListingS;
+  form:scope ext:formListingTableS;
   form:createGenerator ext:formListingTableGenerator;
   form:canAdd true;
   form:addLabel "Add new table listing";
@@ -277,7 +287,7 @@ ext:subFormPropertyGroupF a form:Field ;
 ext:formListingGenerator a form:Generator;
   form:prototype [
     form:shape [
-      a form:Listing;
+      a form:Listing, form:ListingBasic;
       form:each [
         a form:SubForm;
         form:includes [


### PR DESCRIPTION
## ID
 DL-XXXX

 ## Description

This fixes the case where adding a listing in the form builder's default form would add the new listing item to both the regular and table listing sections. It was solved by not having these listings use the same scope and by adding a new subclass of the form:Listing class called form:ListingBasic

This WILL break existing listings that don't have this form:ListingBasic type. The reason I had to go for this is that there are no negative constraints (i.e. specifying that the item is of type form:Listing but NOT of the type form:ListingTable). I will look into the constraints and see if I can change that too...

 ## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

- Create a new form in the form builder
- add a listing
- add a table listing (previously the created regular listing showed up in the table listing list here too)
- add another listing (previously the created table listing showed up in the list of regular listings here too)

 ## Links to other PR's

 - TODO