### PR TITLE
SFB-100: create concept-scheme and concept model from store instead of direct sparql

### DIFF
--- a/app/components/concept-scheme-uri-selector.hbs
+++ b/app/components/concept-scheme-uri-selector.hbs
@@ -3,7 +3,7 @@
   @options={{this.options}}
   @selected={{this.selected}}
   @onChange={{this.setSelected}}
-  as |singleselect|
+  as |conceptScheme|
 >
-  {{singleselect.prefLabel.value}}
+  {{conceptScheme.label}}
 </PowerSelect>

--- a/app/components/concept-scheme-uri-selector.hbs
+++ b/app/components/concept-scheme-uri-selector.hbs
@@ -1,4 +1,9 @@
 <AuLabel>Kies een concept scheme</AuLabel>
-<PowerSelect @options={{this.options}} @selected={{this.selected}} @onChange={{this.setSelected}} as |singleselect|>
+<PowerSelect
+  @options={{this.options}}
+  @selected={{this.selected}}
+  @onChange={{this.setSelected}}
+  as |singleselect|
+>
   {{singleselect.prefLabel.value}}
 </PowerSelect>

--- a/app/components/concept-scheme-uri-selector.js
+++ b/app/components/concept-scheme-uri-selector.js
@@ -16,15 +16,19 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
 
   @action
   async loadOptions() {
-    const conceptSchemes = await this.store.query('concept-scheme', {
-      include: 'concepts',
-    });
+    const conceptSchemes = await this.store.query('concept-scheme', {});
 
     this.options = this.getSortedOptions(conceptSchemes);
   }
 
   async update() {
-    const concepts = await this.selected.concepts;
+    const concepts = await this.store.query('concept', {
+      filter: {
+        'concept-schemes': {
+          ':uri:': this.selected.uri,
+        },
+      },
+    });
 
     this.args.update({
       uri: this.selected.uri,

--- a/app/controllers/codelijsten.js
+++ b/app/controllers/codelijsten.js
@@ -5,11 +5,20 @@ import { tracked } from '@glimmer/tracking';
 export default class CodelijstenController extends Controller {
   @tracked scheme;
 
-  @action update(scheme) {
+  @action updateSelectedSchemeTo(scheme) {
     this.scheme = scheme;
   }
 
   @action previousRoute() {
     window.history.back();
+  }
+
+  get configurationCode() {
+    const jsonConfigCode = {
+      conceptScheme: this.scheme.uri,
+      searchEnabled: true,
+    };
+
+    return JSON.stringify(jsonConfigCode, null, 2).trim();
   }
 }

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -3,7 +3,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class ConceptSchemeModel extends Model {
   @attr uri;
   @attr preflabel;
-  @hasMany('concept', { inverse: null, async: false }) concepts;
+  @hasMany('concept', { inverse: null, async: true }) concepts;
 
   get label() {
     return this.preflabel;

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -1,0 +1,7 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class ConceptSchemeModel extends Model {
+  @attr uuid;
+  @attr label;
+  @hasMany('concept', { inverse: null }) concepts;
+}

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -1,7 +1,11 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class ConceptSchemeModel extends Model {
-  @attr uuid;
-  @attr label;
-  @hasMany('concept', { inverse: null }) concepts;
+  @attr uri;
+  @attr preflabel;
+  @hasMany('concept', { inverse: null, async: false }) concepts;
+
+  get label() {
+    return this.preflabel;
+  }
 }

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -3,7 +3,7 @@ import Model, { attr, hasMany } from '@ember-data/model';
 export default class ConceptModel extends Model {
   @attr uri;
   @attr preflabel;
-  @hasMany('concept-scheme', { inverse: null, async: false }) conceptSchemes;
+  @hasMany('concept-scheme', { inverse: null, async: true }) conceptSchemes;
 
   get label() {
     return this.preflabel;

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -1,0 +1,7 @@
+import Model, { attr, hasMany } from '@ember-data/model';
+
+export default class ConceptModel extends Model {
+  @attr uuid;
+  @attr label;
+  @hasMany('concept-scheme', { inverse: null }) conceptSchemes;
+}

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -1,7 +1,11 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class ConceptModel extends Model {
-  @attr uuid;
-  @attr label;
-  @hasMany('concept-scheme', { inverse: null }) conceptSchemes;
+  @attr uri;
+  @attr preflabel;
+  @hasMany('concept-scheme', { inverse: null, async: false }) conceptSchemes;
+
+  get label() {
+    return this.preflabel;
+  }
 }

--- a/app/styles/project/_c-playground.scss
+++ b/app/styles/project/_c-playground.scss
@@ -5,7 +5,7 @@
 
 .playground__codelist,
 .playground__show {
-  padding: $au-unit*1.5;
+  padding: $au-unit * 1.5;
   width: 45%;
 }
 
@@ -21,6 +21,12 @@
 
 .playground__codelist {
   overflow: auto;
+}
+.playground__codelist_code {
+  overflow-x: auto;
+  display: flex;
+  flex-wrap: wrap;
+  background-color: $au-gray-100;
 }
 
 .playground__edit .playground__edit__header {

--- a/app/templates/codelijsten.hbs
+++ b/app/templates/codelijsten.hbs
@@ -7,7 +7,12 @@
   </div>
   <div class="au-c-toolbar__group">
     <AuButtonGroup>
-      <AuButton @skin="secondary" @icon="arrow-left" @iconAlignment="left" {{on 'click' this.previousRoute}}>Terug naar formulierenbouwer</AuButton>
+      <AuButton
+        @skin="secondary"
+        @icon="arrow-left"
+        @iconAlignment="left"
+        {{on "click" this.previousRoute}}
+      >Terug naar formulierenbouwer</AuButton>
     </AuButtonGroup>
   </div>
 </div>
@@ -17,38 +22,62 @@
   <div class="au-c-main-container__content">
     <div class="playground">
       <div class="playground__codelist">
+        {{!
+          Glimmer components only have two lifecycle hooks
+          This method will set the view to start without a scheme selected
+        }}
+        {{this.updateSelectedSchemeTo undefined}}
 
-        <AuHeading @level="2" @skin="3" class="au-u-light">Kies een concept scheme waarvan u de inhoud wil bekijken</AuHeading>
+        <AuHeading @level="2" @skin="3" class="au-u-light">Kies een concept
+          scheme waarvan u de inhoud wil bekijken</AuHeading>
 
         <div class="au-u-margin-top au-u-margin-bottom">
-          <ConceptSchemeUriSelector @update={{this.update}}/>
+          <ConceptSchemeUriSelector @update={{this.updateSelectedSchemeTo}} />
         </div>
 
         <div class="au-u-margin-bottom">
           <AuLabel>URI: geeft meer informatie en activeert de concept scheme</AuLabel>
           <AuContent class="au-u-margin-bottom">
             {{#if this.scheme.uri}}
-              <p>
-                <a class="au-c-link" href={{this.scheme.uri}} rel="noopener noreferrer" target="_blank">{{this.scheme.uri}}</a>
-              </p>
-              <div>
-                code:
-                <code>
-                  {"conceptScheme":
-                    "{{this.scheme.uri}}",
-                    "searchEnabled": true
-                  }
-                </code>
-              </div>
+              <AuPanel as |Section|>
+                <Section class="playground__codelist_code">
+                  <a
+                    class="au-c-link"
+                    href={{this.scheme.uri}}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >{{this.scheme.uri}}</a>
+                </Section>
+              </AuPanel>
+              <AuPanel as |Section|>
+                <Section class="playground__codelist_code">
+                  <pre>{{this.configurationCode}}</pre>
+                </Section>
+              </AuPanel>
             {{else}}
               <AuHelpText @skin="tertiary">Kies eerst een concept scheme.</AuHelpText>
             {{/if}}
-            <AuAlert @icon="info-circle" @title="Hoe de concept scheme gebruiken:" @skin="info" @size="small">
+            <AuAlert
+              @icon="info-circle"
+              @title="Hoe de concept scheme gebruiken:"
+              @skin="info"
+              @size="small"
+            >
               <ul class="au-u-margin-bottom-small">
-                <li>Kopieer de link en plak ze bij <strong>form:options</strong> en vervang de link achter <strong>conceptScheme</strong> om de concept scheme te activeren.</li>
-                <li>Sommige links omvatten meer informatie over de concept scheme zelf. Klik op de link om die informatie te achterhalen.</li>
+                <li>Kopieer de link en plak ze bij
+                  <strong>form:options</strong>
+                  en vervang de link achter
+                  <strong>conceptScheme</strong>
+                  om de concept scheme te activeren.</li>
+                <li>Sommige links omvatten meer informatie over de concept
+                  scheme zelf. Klik op de link om die informatie te achterhalen.</li>
               </ul>
-              <img src="/img/example-concept-scheme.png" style="border: 1px solid lightgray;" alt="concept scheme" {{! template-lint-disable no-inline-styles}}>
+              <img
+                src="/img/example-concept-scheme.png"
+                style="border: 1px solid lightgray;"
+                alt="concept scheme"
+                {{! template-lint-disable no-inline-styles}}
+              />
             </AuAlert>
           </AuContent>
         </div>
@@ -67,7 +96,8 @@
               {{/each}}
             </ul>
           {{else}}
-            <AuHelpText @skin="tertiary">Kies eerst een concept scheme in het linkerveld.</AuHelpText>
+            <AuHelpText @skin="tertiary">Kies eerst een concept scheme in het
+              linkerveld.</AuHelpText>
           {{/if}}
         </AuContent>
       </div>

--- a/tests/unit/models/concept-scheme-test.js
+++ b/tests/unit/models/concept-scheme-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'frontend-form-builder/tests/helpers';
+
+module('Unit | Model | concept scheme', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('concept-scheme', {});
+    assert.ok(model);
+  });
+});

--- a/tests/unit/models/concept-test.js
+++ b/tests/unit/models/concept-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+
+import { setupTest } from 'frontend-form-builder/tests/helpers';
+
+module('Unit | Model | concept', function (hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function (assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('concept', {});
+    assert.ok(model);
+  });
+});


### PR DESCRIPTION
## ID
 [SFB-100](https://binnenland.atlassian.net/browse/SFB-100)

 ## Description

The concept schemes are fetched with a direct sparql query in the frontend. Change this by getting the concept-schemes with their concepts to be get from the store `this.store.query('concept-scheme')`
 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [x] Breaking change
 - [ ] Other

 ## How to test

Checkout the app for the frontend on the the `SFB-100` branch. Make sure all the migrations have run.

Check the code if the `concept-scheme-uri-selector` is using the store instead of a direct sparql query. All options should be visible with their concepts on the left side.

 ## Links to other PR's

 - https://github.com/lblod/app-form-builder/pull/7