### PR TITLE
SFB-73: Optimise codelist data flow (DEPRECATED)

### DIFF
--- a/app/components/concept-scheme-uri-selector.js
+++ b/app/components/concept-scheme-uri-selector.js
@@ -50,12 +50,18 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
             ':uri:': config.conceptScheme,
           },
         });
-        if ([...conceptSchemes].length >= 1) {
-          this.selected = {
-            label: [...conceptSchemes][0].label,
-            uri: config.conceptScheme,
-          };
+
+        if (!conceptSchemes || [...conceptSchemes].length == 0) {
+          console.error(
+            `Coudl not find concept-scheme: '${config.conceptScheme}'`
+          );
+          return;
         }
+
+        this.selected = {
+          label: [...conceptSchemes][0].label,
+          uri: config.conceptScheme,
+        };
       } catch (error) {
         console.error(
           `Could not parse the form:options to JSON. (${sourceNode.value})`,
@@ -96,7 +102,6 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
 
   @action
   setSelected(value) {
-    console.log(value);
     this.selected = value;
     this.update();
   }
@@ -123,19 +128,15 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
       sourceNode: sourceNode,
     };
 
-    // Cleanup old value(s) in the store
-    const matches = triplesForPath(this.args, true).values;
-    console.log({ matches });
-    const matchingOptions = matches.filter((m) =>
-      this.options.find((opt) => m.equals(opt.subject))
-    );
-    console.log({ matchingOptions });
-    matchingOptions.forEach((m) =>
-      updateSimpleFormValue(storeOptions, undefined, m)
-    );
-
     // Insert new value in the store
     if (this.selected) {
+      formStore.removeMatches(
+        sourceNode,
+        FORM('options'),
+        undefined,
+        graphs.sourceGraph
+      );
+
       const optionConfig = {
         conceptScheme: this.selected.uri,
         searchEnabled: true,

--- a/app/components/concept-scheme-uri-selector.js
+++ b/app/components/concept-scheme-uri-selector.js
@@ -2,10 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import {
-  triplesForPath,
-  updateSimpleFormValue,
-} from '@lblod/submission-form-helpers';
+import { updateSimpleFormValue } from '@lblod/submission-form-helpers';
 import { Literal } from 'rdflib';
 import { getTriplesWithNodeAsSubject } from '../utils/forking-store-helpers';
 import { FORM } from '../utils/rdflib';

--- a/app/components/concept-scheme-uri-selector.js
+++ b/app/components/concept-scheme-uri-selector.js
@@ -20,7 +20,10 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
   constructor() {
     super(...arguments);
     this.loadOptions();
-    this.initiateSelected.perform();
+
+    if (this.isForSelectingConceptSchemeOptions()) {
+      this.initiateSelected.perform();
+    }
   }
 
   isForSelectingConceptSchemeOptions() {

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -36,7 +36,9 @@
         </h1>
       </Group>
       <Group class="au-c-toolbar__group--actions">
-        <AuLink @route="codelijsten">Codelijsten</AuLink>
+        {{#unless this.features.HIDE_CODELIST_BUTTON_IN_TOOLBAR}}
+          <AuLink @route="codelijsten">Codelijsten</AuLink>
+        {{/unless}}
         <AuDropdown @title="Formulier acties" @alignment="right" role="menu">
           <AuButton
             @skin="link"

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -8,6 +8,7 @@ export default class ToolbarComponent extends Component {
   @service router;
   @service toaster;
   @service('form-code-manager') formCodeManager;
+  @service features;
 
   @tracked showDeleteModal = false;
 

--- a/app/routes/formbuilder/edit.js
+++ b/app/routes/formbuilder/edit.js
@@ -4,6 +4,7 @@ import { registerFormFields } from '@lblod/ember-submission-form-fields';
 import PropertyGroupSelector from '../../components/rdf-form-fields/property-group-selector';
 import ValidationConceptSchemeSelectorComponent from '../../components/rdf-form-fields/validation-concept-scheme-selector';
 import { getLocalFileContentAsText } from '../../utils/get-local-file-content';
+import ConceptSchemeUriSelectorComponent from '../../components/concept-scheme-uri-selector';
 import CountryCodeConceptSchemeSelectorComponent from '../../components/rdf-form-fields/country-code-concept-scheme-selector';
 import { GRAPHS } from '../../controllers/formbuilder/edit';
 
@@ -69,6 +70,11 @@ export default class FormbuilderEditRoute extends Route {
         displayType:
           'http://lblod.data.gift/display-types/countryCodeConceptSchemeSelector',
         edit: CountryCodeConceptSchemeSelectorComponent,
+      },
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/conceptSchemeUriSelectorComponent',
+        edit: ConceptSchemeUriSelectorComponent,
       },
     ]);
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -18,7 +18,9 @@ module.exports = function (environment) {
       // Here you can pass flags/options to your application instance
       // when it is created
     },
-    featureFlags: {},
+    featureFlags: {
+      HIDE_CODELIST_BUTTON_IN_TOOLBAR: true,
+    },
   };
 
   if (environment === 'development') {

--- a/public/forms/builder/form.ttl
+++ b/public/forms/builder/form.ttl
@@ -128,11 +128,11 @@ ext:formNodesL a form:Listing;
 ##########################################################
 ext:formNodesFormItem a form:SubForm;
   form:includes ext:formNodesNameF;
-  form:includes ext:formNodesTypeF;
   form:includes ext:formNodeHelpTextF;
   form:includes ext:formNodePropertyGroupF;
-  form:hasFieldGroup ext:formFieldPg ;
-  form:hasConditionalFieldGroup fields:codelistSelectionCFG .
+  form:hasFieldGroup ext:formFieldPg .
+
+  ext:formFieldPg form:hasField ext:formNodesTypeF .
 
 ext:formNodesNameF a form:Field ;
   sh:name "Field name" ;
@@ -150,7 +150,8 @@ ext:formNodesTypeF a form:Field ;
    """;
   form:displayType displayTypes:conceptSchemeSelector ;
   form:options """{"conceptScheme":"http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6","searchEnabled":true}""" ;
-  sh:group ext:formFieldPg .
+  sh:group ext:formFieldPg ;
+  form:hasConditionalFieldGroup fields:codelistSelectionCFG .
 
 fieldGroups:codelistSelectorFG a form:FieldGroup ;
   form:hasField ext:formNodeOptionsF .
@@ -159,7 +160,7 @@ fields:codelistSelectionCFG a form:ConditionalFieldGroup ;
   form:conditions
     [ a form:MatchValues ;
         form:grouping form:Bag ;
-        sh:path rdf:type ;
+        sh:path form:displayType ;
         form:valuesIn (
           <http://lblod.data.gift/display-types/conceptSchemeMultiSelector>
           <http://lblod.data.gift/display-types/conceptSchemeRadioButtons>

--- a/public/forms/builder/form.ttl
+++ b/public/forms/builder/form.ttl
@@ -184,6 +184,12 @@ ext:formNodeOptionsF a form:Field;
   sh:order 5 ;
   sh:path form:options ;
   form:displayType displayTypes:textArea;
+  form:validations
+    [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path form:options ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+    ] ;
   sh:group ext:formFieldPg .
 
 ext:formNodePropertyGroupF a form:Field;

--- a/public/forms/builder/form.ttl
+++ b/public/forms/builder/form.ttl
@@ -183,13 +183,7 @@ ext:formNodeOptionsF a form:Field;
   sh:name "Extra configuration options as JSON" ;
   sh:order 5 ;
   sh:path form:options ;
-  form:displayType displayTypes:textArea;
-  form:validations
-    [ a form:RequiredConstraint ;
-        form:grouping form:Bag ;
-        sh:path form:options ;
-        sh:resultMessage "Dit veld is verplicht."@nl
-    ] ;
+  form:displayType displayTypes:conceptSchemeUriSelectorComponent ;
   sh:group ext:formFieldPg .
 
 ext:formNodePropertyGroupF a form:Field;

--- a/public/forms/builder/form.ttl
+++ b/public/forms/builder/form.ttl
@@ -6,6 +6,9 @@
 @prefix schema: <http://schema.org/>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>.
+@prefix conceptSchemes: <http://lblod.data.gift/concept-schemes/>.
+@prefix fields: <http://data.lblod.info/fields/> .
+@prefix fieldGroups: <http://data.lblod.info/field-groups/> .
 
 ##########################################################
 # form
@@ -127,9 +130,9 @@ ext:formNodesFormItem a form:SubForm;
   form:includes ext:formNodesNameF;
   form:includes ext:formNodesTypeF;
   form:includes ext:formNodeHelpTextF;
-  form:includes ext:formNodeOptionsF;
   form:includes ext:formNodePropertyGroupF;
-  form:hasFieldGroup ext:formFieldPg.
+  form:hasFieldGroup ext:formFieldPg ;
+  form:hasConditionalFieldGroup fields:codelistSelectionCFG .
 
 ext:formNodesNameF a form:Field ;
   sh:name "Field name" ;
@@ -148,6 +151,22 @@ ext:formNodesTypeF a form:Field ;
   form:displayType displayTypes:conceptSchemeSelector ;
   form:options """{"conceptScheme":"http://lblod.data.gift/concept-schemes/c5a91bd7-3eb5-4d69-a51b-9bac6bf345f6","searchEnabled":true}""" ;
   sh:group ext:formFieldPg .
+
+fieldGroups:codelistSelectorFG a form:FieldGroup ;
+  form:hasField ext:formNodeOptionsF .
+
+fields:codelistSelectionCFG a form:ConditionalFieldGroup ;
+  form:conditions
+    [ a form:MatchValues ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:valuesIn (
+          <http://lblod.data.gift/display-types/conceptSchemeMultiSelector>
+          <http://lblod.data.gift/display-types/conceptSchemeRadioButtons>
+          <http://lblod.data.gift/display-types/conceptSchemeSelector>
+        );
+    ] ;
+  form:hasFieldGroup fieldGroups:codelistSelectorFG .
 
 ext:formNodeHelpTextF a form:Field;
   sh:name "Helptext" ;


### PR DESCRIPTION
## ID
 [SFB-73](https://binnenland.atlassian.net/browse/SFB-73)

 ## Description

 Create a conditional dropdown for selecting the codelist. When the input field type is a `conceptSchemeMultiSelector`, `conceptSchemeRadioButtons`, `conceptSchemeSelector`. The codelist `concept-schemes uri selector` dropdown should be shown. When selecting a `concept-scheme` with that dropdown the fields `form:options` is added to the field subject.

**Field options**
```
form:options
        """{"conceptScheme":"http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode","searchEnabled":true}""";
```

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [x] Breaking change
 - [ ] Other

 ## How to test

Select a input field type that is one of above and add a codelist to it. See if it is visualized in the preview screen.(visualization is only possible after PR: https://github.com/lblod/frontend-form-builder/pull/67 is merged)

 ## Links to other PR's

 - /