### PR TITLE
SFB-114: remove the bewerk column + make the name clickable 

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -35,7 +35,7 @@
               class="au-u-visible-small-up" />
             <AuDataTableThSortable @label='Aangepast op' @field='modified' @currentSorting={{this.sort}}
               class="au-u-visible-small-up" />
-            <th colspan="3">Acties</th>
+            <th colspan="2">Acties</th>
           </c.header>
           <c.body as |generatedForm|>
             <td class="au-u-visible-medium-up">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -15,13 +15,13 @@
 <main id="main" class="au-c-main-container">
   <div class="au-c-main-container__content">
     <div class="au-c-body-container">
-      <AuDataTable 
-        @content={{this.model}} 
-        @isLoading={{this.isLoadingModel}} 
+      <AuDataTable
+        @content={{this.model}}
+        @isLoading={{this.isLoadingModel}}
         @noDataMessage="Geen formulieren gevonden"
-        @sort={{this.sort}} 
-        @page={{this.page}} 
-        @size={{this.size}} 
+        @sort={{this.sort}}
+        @page={{this.page}}
+        @size={{this.size}}
         as |t|
       >
         <t.content as |c|>
@@ -38,20 +38,19 @@
             <th colspan="3">Acties</th>
           </c.header>
           <c.body as |generatedForm|>
-            <td class="au-u-visible-medium-up">{{generatedForm.label}}</td>
+            <td class="au-u-visible-medium-up">
+              <AuLink @route="formbuilder.edit" @model={{generatedForm.id}} @ariaHidden={{true}}>{{generatedForm.label}}</AuLink>
+            </td>
             <td class="au-u-visible-medium-up">{{generatedForm.comment}}</td>
             <td class="au-u-visible-medium-up">{{format-date generatedForm.created}}</td>
             <td class="au-u-visible-medium-up">{{format-date-time generatedForm.modified}}</td>
-            <td class="au-u-visible-medium-up">
-              <AuLink @route="formbuilder.edit" @model={{generatedForm.id}} @icon="pencil" @iconAlignment="left" @ariaHidden={{true}}>Bewerk</AuLink>
-            </td>
             <td class="au-u-visible-medium-up">
               <AuButton
               @skin="link"
                 @icon="bin"
                 @alert={{true}}
                 {{on "click" (fn this.openDeleteModal generatedForm)}}
-              >  
+              >
                 Verwijder
               </AuButton>
             </td>


### PR DESCRIPTION
## ID
 [SFB-114](https://binnenland.atlassian.net/browse/SFB-114)

 ## Description

Remove the action `bewerk` and make the name clickable to go to the edit page of the form.
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/7f6203aa-ce64-4bef-ad51-78d31f2ba1d9)
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/10a6899a-1175-4cb0-ba71-6363d8464272)

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

- Make sure it is possible to go to the edit page of the form.
- Bewerk action is removed
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/52dca414-8684-4214-bc1e-886e79b1de2f)


 ## Links to other PR's

