### PR TITLE
SFB-116: add pencil icon next to title that opens the edit form name

### DIFF
--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -83,7 +83,7 @@
 <AuModal
   @title="Bewerk naam en beschrijving"
   @modalOpen={{this.showEditModal}}
-  @closeModal={{fn (mut this.showEditModal) false}}
+  @closeModal={{this.closeEditNameModal}}
   as |Modal|
 >
   <Modal.Body>

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -31,21 +31,21 @@
             </AuPill>
           {{/if}}
         </div>
-        <h1 class="au-c-app-chrome__title">
-          {{@model.label}}
-        </h1>
+        <div class="titleEdit">
+          <h1 class="au-c-app-chrome__title">
+            {{@model.label}}
+          </h1>
+          <AuButton
+            @skin={{"link-secondary"}}
+            @icon={{"pencil"}}
+            @hideText={{true}}
+            {{on "click" (fn (mut this.showEditModal) true)}}
+          />
+        </div>
       </Group>
       <Group class="au-c-toolbar__group--actions">
         <AuLink @route="codelijsten">Codelijsten</AuLink>
         <AuDropdown @title="Formulier acties" @alignment="right" role="menu">
-          <AuButton
-            @skin="link"
-            @icon="copy"
-            role="menuitem"
-            {{on "click" (fn (mut this.showEditModal) true)}}
-          >
-            Bewerk naam en beschrijving
-          </AuButton>
           <AuButton
             @skin="link"
             @icon="export"

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -77,4 +77,11 @@ export default class ToolbarComponent extends Component {
 
     this.args.setFormChanged(false);
   }
+
+  @action
+  closeEditNameModal() {
+    this.showEditModal = false;
+    this.formLabel = this.args.model.label;
+    this.formComment = this.args.model.comment;
+  }
 }

--- a/app/styles/project/_c-app-chrome.scss
+++ b/app/styles/project/_c-app-chrome.scss
@@ -10,24 +10,24 @@
 
    /* Component
       ========================================================================== */
-   
+
    .au-c-app-chrome {
      position: relative;
      z-index: 9997;
      background-color: $au-white;
      box-shadow: 0 1px 3px rgba($au-gray-900, .1), 0 4px 20px rgba($au-gray-900, .035), 0 1px 1px rgba($au-gray-900, .025);
    }
-   
+
    .au-c-app-chrome-container {
      height: calc(100vh - 9.6rem);
    }
-   
+
    .au-c-app-chrome__entity {
      position: relative;
      font-weight: $au-medium;
      padding-left: $au-unit-small;
      margin-left: $au-unit-small;
-   
+
      &::before {
        content: "";
        display: block;
@@ -40,7 +40,7 @@
        background-color: $au-gray-300;
      }
    }
-   
+
    .au-c-app-chrome__status {
      font-style: italic;
      display: inline-flex;
@@ -50,7 +50,13 @@
      color: $au-gray-600;
      padding: $au-unit-tiny * .5;
    }
-   
+
+   .titleEdit {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
    .au-c-app-chrome__title {
      @include au-font-size($au-h4);
      display: block;
@@ -64,11 +70,12 @@
      border: .1rem solid transparent;
      border-radius: $au-radius;
      max-width: $au-unit-huge * 3.5;
-   
+     margin-bottom: 5px;
+
      .au-c-button {
        // position: initial;
      }
-   
+
      .au-c-button:after {
        content: "";
        position: absolute;
@@ -77,77 +84,77 @@
        width: 100%;
        height: 100%;
      }
-   
+
      @include mq(1140px) {
        max-width: $au-unit-huge * 4.5;
      }
-   
+
      @include mq(1280px) {
        max-width: $au-unit-huge * 5.5;
      }
-   
+
      @include mq(1340px) {
        max-width: $au-unit-huge * 6.5;
      }
-   
+
      @include mq(large) {
        max-width: $au-unit-huge * 7.5;
      }
-   
+
      @include mq(1500px) {
        max-width: $au-unit-huge * 8.5;
      }
    }
-   
+
    .au-c-app-chrome__title--edit {
      transition: color $au-transition, border $au-transition;
      color: $au-gray-800;
-   
+
      &:hover,
      &:focus {
        color: $au-gray-700;
        border: .1rem solid $au-gray-200;
      }
-   
+
      &:focus {
        outline: .2rem dashed $au-yellow-400;
      }
    }
-   
+
    .au-c-app-chrome__title-fade {
      color: $au-gray-600;
    }
-   
+
    .au-c-app-chrome__title-group {
      display: flex;
      flex-wrap: nowrap;
      width: $au-unit-huge * 3.5;
-   
+
      @include mq(medium) {
        width: $au-unit-huge * 3.5;
      }
-   
+
      @include mq(1140px) {
        width: $au-unit-huge * 4.5;
      }
-   
+
      @include mq(1280px) {
        width: $au-unit-huge * 5.5;
      }
-   
+
      @include mq(1340px) {
        width: $au-unit-huge * 6.5;
      }
-   
+
      @include mq(large) {
        width: $au-unit-huge * 7.5;
      }
-   
+
      @include mq(1500px) {
        width: $au-unit-huge * 8.5;
      }
    }
-   
+
    .au-c-app-chrome__title-input {
      @include au-font-size($au-h4);
      font-family: $au-font;
@@ -161,12 +168,12 @@
      border-top-right-radius: 0;
      border-bottom-right-radius: 0;
      color: $au-gray-800;
-   
+
      &:focus {
        outline: 0;
      }
    }
-   
+
    .au-c-button.au-c-app-chrome__title-button {
      border-color: $au-gray-300;
      border-top-right-radius: $au-radius;
@@ -174,24 +181,24 @@
      border-left: 0;
      padding-left: $au-unit-tiny;
      padding-right: $au-unit-tiny;
-   
+
      &:hover {
        border-color: $au-gray-300;
        box-shadow: none;
        background-color: $au-gray-100;
        color: $au-gray-800;
      }
-   
+
      .au-c-icon {
        width: 1.9rem;
        height: 1.9rem;
      }
    }
-   
+
    // Toolbar extensions
    .au-c-toolbar--wrap {
      flex-wrap: wrap;
-   
+
      @include mq(medium) {
        flex-wrap: nowrap;
      }


### PR DESCRIPTION
## ID
 [SFB-116](https://binnenland.atlassian.net/browse/SFB-116)

 ## Description

The action to edit the name of a form is hidden behind the `formulier acties` dropdown. Add a pencil icon next to the Title and let it open the edit name and description modal.

 ## Type of change

 - [x] Small change
 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Click the `formulier acties` dropdown => the option to edit should be removed
2. Click on the pencil icon next to the title of the form and see if the modal opens
3. Change the name see if it updates

 ## Links to other PR's

- /