### PR TITLE
Form overview style updates

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -51,3 +51,13 @@ code {
 .au-o-grid {
   display: block;
 }
+
+.removeTableLines {
+  table {
+    border-collapse: unset !important;
+  }
+  .au-c-data-table__table th + th:after,
+  .au-c-data-table__table td + td:after {
+    border-left: none !important;
+  }
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -56,8 +56,4 @@ code {
   table {
     border-collapse: unset !important;
   }
-  .au-c-data-table__table th + th:after,
-  .au-c-data-table__table td + td:after {
-    border-left: none !important;
-  }
 }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -17,7 +17,7 @@
 
 <main id="main" class="au-c-main-container">
   <div class="au-c-main-container__content">
-    <div class="au-c-body-container">
+    <div class="au-c-body-container removeTableLines">
       <AuDataTable
         @content={{this.model}}
         @isLoading={{this.isLoadingModel}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -38,7 +38,7 @@
               class="au-u-visible-small-up" />
             <AuDataTableThSortable @label='Aangepast op' @field='modified' @currentSorting={{this.sort}}
               class="au-u-visible-small-up" />
-            <th colspan="2"></th>
+            <th colspan="2">Acties</th>
           </c.header>
           <c.body as |generatedForm|>
             <td class="au-u-visible-medium-up">

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -38,7 +38,7 @@
               class="au-u-visible-small-up" />
             <AuDataTableThSortable @label='Aangepast op' @field='modified' @currentSorting={{this.sort}}
               class="au-u-visible-small-up" />
-            <th colspan="2">Acties</th>
+            <th colspan="2"></th>
           </c.header>
           <c.body as |generatedForm|>
             <td class="au-u-visible-medium-up">
@@ -48,6 +48,12 @@
             <td class="au-u-visible-medium-up">{{format-date generatedForm.created}}</td>
             <td class="au-u-visible-medium-up">{{format-date-time generatedForm.modified}}</td>
             <td class="au-u-visible-medium-up">
+              <LinkTo @route="user-tests.new" @query={{hash form=generatedForm.id}} class="au-c-link">
+                <AuIcon @icon="eye" @alignment="left" @size="large" @ariaHidden={{true}} />
+                Preview
+              </LinkTo>
+            </td>
+            <td class="au-u-visible-medium-up">
               <AuButton
               @skin="link"
                 @icon="bin"
@@ -56,12 +62,6 @@
               >
                 Verwijder
               </AuButton>
-            </td>
-            <td class="au-u-visible-medium-up">
-              <LinkTo @route="user-tests.new" @query={{hash form=generatedForm.id}} class="au-c-link">
-                <AuIcon @icon="user-popup" @alignment="left" @size="large" @ariaHidden={{true}} />
-                Test
-              </LinkTo>
             </td>
           </c.body>
         </t.content>


### PR DESCRIPTION
Following https://www.figma.com/file/iwxgR1dVYjIX4AknHe57eH/formbuilder-smallUXchanges?type=design&node-id=0-1&mode=design&t=4b479qUGfDJFqfHY-0

1. Switch form actions to `preview` and `verwijder` 
2. ~Remove the borders in the table~