### PR TITLE
refactor: create split button for form actions and safe

### DIFF
--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -45,29 +45,39 @@
       </Group>
       <Group class="au-c-toolbar__group--actions">
         <AuLink @route="codelijsten">Codelijsten</AuLink>
-        <AuDropdown @title="Formulier acties" @alignment="right" role="menu">
+        <div class="saveSplitButton">
           <AuButton
-            @skin="link"
-            @icon="export"
-            role="menuitem"
-            {{on "click" this.saveLocally}}
+            id="saveSplitButton_save"
+            @disabled={{not @formChanged}}
+            {{on "click" this.updateForm}}
+          >Bewaar</AuButton>
+          <AuDropdown
+            id="saveSplitButton_dropdown"
+            @title=""
+            @hideText={{true}}
+            @alignment="left"
+            role="menu"
+            @skin="primary"
           >
-            Exporteer code
-          </AuButton>
-          <AuButton
-            @skin="link"
-            @icon="bin"
-            role="menuitem"
-            @alert={{true}}
-            {{on "click" (fn (mut this.showDeleteModal) true)}}
-          >
-            Verwijder
-          </AuButton>
-        </AuDropdown>
-        <AuButton
-          @disabled={{not @formChanged}}
-          {{on "click" this.updateForm}}
-        >Bewaar</AuButton>
+            <AuButton
+              @skin="link"
+              @icon="export"
+              role="menuitem"
+              {{on "click" this.saveLocally}}
+            >
+              Exporteer code
+            </AuButton>
+            <AuButton
+              @skin="link"
+              @icon="bin"
+              role="menuitem"
+              @alert={{true}}
+              {{on "click" (fn (mut this.showDeleteModal) true)}}
+            >
+              Verwijder
+            </AuButton>
+          </AuDropdown>
+        </div>
       </Group>
     </AuToolbar>
   </div>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -2,6 +2,7 @@
 @import "project/c-playground";
 @import "project/c-app-chrome";
 @import "project/c-form-builder-edit";
+@import "project/c-app-toolbar";
 
 @import "shame";
 

--- a/app/styles/project/_c-app-toolbar.scss
+++ b/app/styles/project/_c-app-toolbar.scss
@@ -1,0 +1,14 @@
+.saveSplitButton {
+  display: flex;
+  flex-direction: row;
+  #saveSplitButton_save {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  #saveSplitButton_dropdown {
+    button {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+}


### PR DESCRIPTION
[SFB-117](https://binnenland.atlassian.net/browse/SFB-117)

The form options are not used that much move the to a split button next to safe.

![image](https://github.com/lblod/frontend-form-builder/assets/36266973/23b06cbd-2b66-43e3-bb44-628530c22be2)
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/448520e6-157a-4b85-b8ae-d05299a1d6ff)
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/3e0cfebf-d8c1-4fc3-a2b9-79d94af1ded2)
