### PR TITLE
SFB-113: UI prevent duplicate validations on field

### DIFF
--- a/app/components/add-validations-to-form.hbs
+++ b/app/components/add-validations-to-form.hbs
@@ -20,18 +20,36 @@
 
     <AuHr />
 
-    {{#if this.selectedField}}
-      <FieldValidationsForm
-        @fieldSubject={{this.selectedField.subject}}
-        @form={{this.selectedField.form}}
-        @graphs={{this.graphs}}
-        @store={{this.selectedField.store}}
-        @updateTtlCodeWithField={{this.updateTtlCodeWithField.perform}}
-      />
-    {{else}}
-      <span class="formBuilderEdit__noFields">
-        <p class="au-u-h3">No field selected</p>
-      </span>
-    {{/if}}
+    <div class="addValidationsToForm__wrapper">
+      <div class="addValidationsToForm__coverUp">
+        {{#if this.coverUp}}
+          <FieldValidationsForm
+            @fieldSubject={{this.coverUp.subject}}
+            @form={{this.coverUp.form}}
+            @graphs={{this.graphs}}
+            @store={{this.coverUp.store}}
+            @updateTtlCodeWithField={{this.up}}
+          />
+        {{/if}}
+      </div>
+
+      <div class="addValidationsToForm__original">
+        {{#if this.selectedField}}
+          <FieldValidationsForm
+            @fieldSubject={{this.selectedField.subject}}
+            @form={{this.selectedField.form}}
+            @graphs={{this.graphs}}
+            @store={{this.selectedField.store}}
+            @updateTtlCodeWithField={{this.updateTtlCodeWithField.perform}}
+          />
+        {{else}}
+          {{#unless this.coverUp}}
+            <span class="formBuilderEdit__noFields">
+              <p class="au-u-h3">No field selected</p>
+            </span>
+          {{/unless}}
+        {{/if}}
+      </div>
+    </div>
   {{/if}}
 </div>

--- a/app/components/add-validations-to-form.hbs
+++ b/app/components/add-validations-to-form.hbs
@@ -20,6 +20,17 @@
 
     <AuHr />
 
+    <AuAlert
+      @title={{"Attention"}}
+      @skin={{"warning"}}
+      @icon={{"alert-triangle"}}
+      @size={{"small"}}
+      @closable={{false}}
+    >
+      <p>When adding a new validation to the field, the underlying content will
+        be re-rendered.</p>
+    </AuAlert>
+
     {{#if this.selectedField}}
       <FieldValidationsForm
         @fieldSubject={{this.selectedField.subject}}

--- a/app/components/add-validations-to-form.hbs
+++ b/app/components/add-validations-to-form.hbs
@@ -20,36 +20,18 @@
 
     <AuHr />
 
-    <div class="addValidationsToForm__wrapper">
-      <div class="addValidationsToForm__coverUp">
-        {{#if this.coverUp}}
-          <FieldValidationsForm
-            @fieldSubject={{this.coverUp.subject}}
-            @form={{this.coverUp.form}}
-            @graphs={{this.graphs}}
-            @store={{this.coverUp.store}}
-            @updateTtlCodeWithField={{this.up}}
-          />
-        {{/if}}
-      </div>
-
-      <div class="addValidationsToForm__original">
-        {{#if this.selectedField}}
-          <FieldValidationsForm
-            @fieldSubject={{this.selectedField.subject}}
-            @form={{this.selectedField.form}}
-            @graphs={{this.graphs}}
-            @store={{this.selectedField.store}}
-            @updateTtlCodeWithField={{this.updateTtlCodeWithField.perform}}
-          />
-        {{else}}
-          {{#unless this.coverUp}}
-            <span class="formBuilderEdit__noFields">
-              <p class="au-u-h3">No field selected</p>
-            </span>
-          {{/unless}}
-        {{/if}}
-      </div>
-    </div>
+    {{#if this.selectedField}}
+      <FieldValidationsForm
+        @fieldSubject={{this.selectedField.subject}}
+        @form={{this.selectedField.form}}
+        @graphs={{this.graphs}}
+        @store={{this.selectedField.store}}
+        @updateTtlCodeWithField={{this.updateTtlCodeWithField.perform}}
+      />
+    {{else}}
+      <span class="formBuilderEdit__noFields">
+        <p class="au-u-h3">No field selected</p>
+      </span>
+    {{/if}}
   {{/if}}
 </div>

--- a/app/components/add-validations-to-form.hbs
+++ b/app/components/add-validations-to-form.hbs
@@ -26,7 +26,7 @@
         @form={{this.selectedField.form}}
         @graphs={{this.graphs}}
         @store={{this.selectedField.store}}
-        @updateTtlCodeWithField={{this.updateTtlCodeWithField}}
+        @updateTtlCodeWithField={{this.updateTtlCodeWithField.perform}}
       />
     {{else}}
       <span class="formBuilderEdit__noFields">

--- a/app/components/add-validations-to-form.hbs
+++ b/app/components/add-validations-to-form.hbs
@@ -28,10 +28,15 @@
         @store={{this.selectedField.store}}
         @updateTtlCodeWithField={{this.updateTtlCodeWithField.perform}}
       />
-    {{else}}
-      <span class="formBuilderEdit__noFields">
-        <p class="au-u-h3">No field selected</p>
-      </span>
     {{/if}}
+
+    {{#unless this.selectedField}}
+      {{#unless this.updateTtlCodeWithField.isRunning}}
+        <span class="formBuilderEdit__noFields">
+          <p class="au-u-h3">No field selected</p>
+        </span>
+      {{/unless}}
+    {{/unless}}
+
   {{/if}}
 </div>

--- a/app/components/add-validations-to-form.js
+++ b/app/components/add-validations-to-form.js
@@ -16,12 +16,14 @@ import { addValidationTriplesToFormNodesL } from '../utils/validation/add-field-
 import { getFieldAndValidationTriples } from '../utils/get-field-and-validation-triples';
 import { areValidationsInGraphValidated } from '../utils/validation/are-validations-in-graph-validated';
 import { createFieldDataForSubject } from '../utils/create-field-data-for-subject';
+import { getTtlWithDuplicateValidationsRemoved } from '../utils/clean-up-ttl/remove-all-duplicate-validations';
 
 export default class AddValidationsToFormComponent extends Component {
   @tracked fields;
 
   @service toaster;
   @tracked selectedField;
+  @service('form-code-manager') formCodeManager;
 
   builderStore;
   savedBuilderTtlCode;
@@ -97,11 +99,17 @@ export default class AddValidationsToFormComponent extends Component {
       this.graphs.sourceGraph
     );
 
+    if (this.formCodeManager.isTtlTheSameAsLatest(newBuilderForm)) {
+      return;
+    }
+
     if (
       areValidationsInGraphValidated(this.builderStore, this.graphs.sourceGraph)
     ) {
-      this.args.onNewBuilderForm(newBuilderForm);
-      this.savedBuilderTtlCode = newBuilderForm;
+      const ttlWithoutDuplicateValidations =
+        getTtlWithDuplicateValidationsRemoved(newBuilderForm);
+      this.args.onNewBuilderForm(ttlWithoutDuplicateValidations);
+      this.savedBuilderTtlCode = ttlWithoutDuplicateValidations;
     }
   }
 

--- a/app/components/field-validations-form.hbs
+++ b/app/components/field-validations-form.hbs
@@ -1,9 +1,11 @@
-<RdfForm
-  @groupClass="au-o-grid__item"
-  @form={{this.form}}
-  @graphs={{this.graphs}}
-  @formStore={{this.store}}
-  @forceShowErrors={{false}}
-  @useNewListingLayout={{true}}
-  @sourceNode={{this.graphs.sourceNode}}
-/>
+<span class="fieldValidations__fadeIn">
+  <RdfForm
+    @groupClass="au-o-grid__item"
+    @form={{this.form}}
+    @graphs={{this.graphs}}
+    @formStore={{this.store}}
+    @forceShowErrors={{false}}
+    @useNewListingLayout={{true}}
+    @sourceNode={{this.graphs.sourceNode}}
+  />
+</span>

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -121,7 +121,10 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
         this.args.graphs.sourceGraph
       );
 
-      if (validationType.value == selectedOption.subject.value) {
+      if (
+        validationType &&
+        validationType.value == selectedOption.subject.value
+      ) {
         return true;
       }
     }

--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -43,9 +43,7 @@ export default class FormbuilderEditController extends Controller {
   handleCodeChange(newCode) {
     if (newCode) {
       this.formCode = newCode;
-      const ttlWithoutDuplicateValidations =
-        getTtlWithDuplicateValidationsRemoved(this.formCode);
-      this.formCodeManager.addFormCode(ttlWithoutDuplicateValidations);
+      this.formCodeManager.addFormCode(this.formCode);
     }
     this.setFormChanged(this.formCodeManager.isLatestDeviatingFromReference());
     this.setupPreviewForm.perform(this.formCodeManager.getTtlOfLatestVersion());

--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -8,6 +8,7 @@ import basicFormTemplate from '../../utils/basic-form-template';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { FORM, RDF } from '../../utils/rdflib';
+import { getTtlWithDuplicateValidationsRemoved } from '../../utils/clean-up-ttl/remove-all-duplicate-validations';
 
 export const GRAPHS = {
   formGraph: new RDFNode('http://data.lblod.info/form'),
@@ -42,7 +43,9 @@ export default class FormbuilderEditController extends Controller {
   handleCodeChange(newCode) {
     if (newCode) {
       this.formCode = newCode;
-      this.formCodeManager.addFormCode(this.formCode);
+      const ttlWithoutDuplicateValidations =
+        getTtlWithDuplicateValidationsRemoved(this.formCode);
+      this.formCodeManager.addFormCode(ttlWithoutDuplicateValidations);
     }
     this.setFormChanged(this.formCodeManager.isLatestDeviatingFromReference());
     this.setupPreviewForm.perform(this.formCodeManager.getTtlOfLatestVersion());

--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -8,7 +8,6 @@ import basicFormTemplate from '../../utils/basic-form-template';
 import { restartableTask, timeout } from 'ember-concurrency';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
 import { FORM, RDF } from '../../utils/rdflib';
-import { getTtlWithDuplicateValidationsRemoved } from '../../utils/clean-up-ttl/remove-all-duplicate-validations';
 
 export const GRAPHS = {
   formGraph: new RDFNode('http://data.lblod.info/form'),

--- a/app/controllers/formbuilder/edit/validations.js
+++ b/app/controllers/formbuilder/edit/validations.js
@@ -11,7 +11,6 @@ export default class FormbuilderEditValidationsController extends Controller {
 
   @action
   handleCodeChange(ttlCode) {
-    this.formCodeManager.addFormCode(ttlCode);
     this.model.handleCodeChange(ttlCode);
   }
 

--- a/app/helpers/is-null-or-undefined.js
+++ b/app/helpers/is-null-or-undefined.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function IsNullOrUndefined([value]) {
+  return value == undefined || value == null;
+});

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -32,7 +32,7 @@
 }
 
 .au-c-tabs {
-  padding: 0;
+  padding: 0
 }
 
 .sf-listing-sub-form {
@@ -41,11 +41,11 @@
 }
 
 code {
-  background-color: #272822;
-  color: #f8f8f2;
-  border-radius: 0.3rem;
-  padding: 20px;
-  white-space: nowrap;
+    background-color: #272822;
+    color: #f8f8f2;
+    border-radius: 0.3rem;
+    padding: 20px;
+    white-space: nowrap;
 }
 
 .au-o-grid {
@@ -55,21 +55,5 @@ code {
 .removeTableLines {
   table {
     border-collapse: unset !important;
-  }
-}
-
-.addValidationsToForm__wrapper {
-  position: relative;
-  .addValidationsToForm__coverUp {
-    pointer-events: none;
-    margin-top: 12px;
-    width: 100%;
-    position: absolute;
-  }
-
-  .addValidationsToForm__original {
-    // background-color: $au-white;
-    position: relative;
-    z-index: 2;
   }
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -32,7 +32,7 @@
 }
 
 .au-c-tabs {
-  padding: 0
+  padding: 0;
 }
 
 .sf-listing-sub-form {
@@ -41,11 +41,11 @@
 }
 
 code {
-    background-color: #272822;
-    color: #f8f8f2;
-    border-radius: 0.3rem;
-    padding: 20px;
-    white-space: nowrap;
+  background-color: #272822;
+  color: #f8f8f2;
+  border-radius: 0.3rem;
+  padding: 20px;
+  white-space: nowrap;
 }
 
 .au-o-grid {
@@ -55,5 +55,27 @@ code {
 .removeTableLines {
   table {
     border-collapse: unset !important;
+  }
+}
+
+.fieldValidations__fadeIn {
+  opacity: 0;
+  transform-origin: top center;
+  animation: fadeInScale 1.5s ease-in forwards;
+}
+
+@keyframes fadeInScale {
+  0% {
+    transform: scaleY(0);
+    opacity: 0;
+  }
+  25% {
+    transform: scaleY(1);
+  }
+  50% {
+    opacity: 0.5;
+  }
+  100% {
+    opacity: 1;
   }
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -32,7 +32,7 @@
 }
 
 .au-c-tabs {
-  padding: 0
+  padding: 0;
 }
 
 .sf-listing-sub-form {
@@ -41,11 +41,11 @@
 }
 
 code {
-    background-color: #272822;
-    color: #f8f8f2;
-    border-radius: 0.3rem;
-    padding: 20px;
-    white-space: nowrap;
+  background-color: #272822;
+  color: #f8f8f2;
+  border-radius: 0.3rem;
+  padding: 20px;
+  white-space: nowrap;
 }
 
 .au-o-grid {
@@ -55,5 +55,21 @@ code {
 .removeTableLines {
   table {
     border-collapse: unset !important;
+  }
+}
+
+.addValidationsToForm__wrapper {
+  position: relative;
+  .addValidationsToForm__coverUp {
+    pointer-events: none;
+    margin-top: 12px;
+    width: 100%;
+    position: absolute;
+  }
+
+  .addValidationsToForm__original {
+    // background-color: $au-white;
+    position: relative;
+    z-index: 2;
   }
 }

--- a/app/utils/clean-up-ttl/remove-all-duplicate-validations.js
+++ b/app/utils/clean-up-ttl/remove-all-duplicate-validations.js
@@ -1,0 +1,96 @@
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { FORM } from '../rdflib';
+import { GRAPHS } from '../../controllers/formbuilder/edit';
+import {
+  getRdfTypeOfNode,
+  getTriplesWithNodeAsSubject,
+} from '../forking-store-helpers';
+
+export function getTtlWithDuplicateValidationsRemoved(ttlCode) {
+  const store = new ForkingStore();
+  store.parse(ttlCode, GRAPHS.sourceGraph, 'text/turtle');
+
+  const validations = store.match(
+    undefined,
+    FORM('validations'),
+    undefined,
+    GRAPHS.sourceGraph
+  );
+
+  const mappedValidationsForSubjects =
+    getMappedValidationSubjectsPerNode(validations);
+  for (const subjectWithValidations of mappedValidationsForSubjects) {
+    const validationSubjectsToRemove = getValidationSubjectToRemove(
+      subjectWithValidations.subject,
+      subjectWithValidations.validationSubjects,
+      store
+    );
+
+    for (const subjectToRemove of validationSubjectsToRemove) {
+      const foundValidationNodeToRemove = store.match(
+        subjectWithValidations.subject,
+        FORM('validations'),
+        subjectToRemove,
+        GRAPHS.sourceGraph
+      );
+      if (!foundValidationNodeToRemove) {
+        console.error(
+          `Could not get validation to remove of node`,
+          subjectWithValidations.subject,
+          subjectToRemove
+        );
+        continue;
+      }
+
+      store.removeStatements([
+        ...foundValidationNodeToRemove,
+        ...getTriplesWithNodeAsSubject(
+          subjectToRemove,
+          store,
+          GRAPHS.sourceGraph
+        ),
+      ]);
+    }
+  }
+  return store.serializeDataMergedGraph(GRAPHS.sourceGraph);
+}
+
+function getMappedValidationSubjectsPerNode(validations) {
+  const validationsPerSubject = [];
+  const subjects = validations.map((validation) => validation.subject.value);
+  const uniqueSubjects = new Array(...new Set(subjects));
+
+  const config = [];
+  for (const validation of validations) {
+    const index = validation.subject.value;
+    if (!config[index]) {
+      config[index] = {
+        subject: validation.subject,
+        validationSubjects: [],
+      };
+    }
+
+    config[index].validationSubjects.push(validation.object);
+  }
+
+  for (const validationSubject of uniqueSubjects) {
+    validationsPerSubject.push(config[validationSubject]);
+  }
+
+  return validationsPerSubject;
+}
+
+function getValidationSubjectToRemove(subject, validationSubjects, store) {
+  const rdfTypesToKeep = [];
+
+  return validationSubjects.filter((subject) => {
+    const rdfType = getRdfTypeOfNode(subject, store, GRAPHS.sourceGraph);
+
+    if (!rdfTypesToKeep.includes(rdfType.value)) {
+      rdfTypesToKeep.push(rdfType.value);
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/app/utils/clean-up-ttl/remove-all-duplicate-validations.js
+++ b/app/utils/clean-up-ttl/remove-all-duplicate-validations.js
@@ -7,6 +7,7 @@ import {
 } from '../forking-store-helpers';
 
 export function getTtlWithDuplicateValidationsRemoved(ttlCode) {
+  let hasTtlChanged = false;
   const store = new ForkingStore();
   store.parse(ttlCode, GRAPHS.sourceGraph, 'text/turtle');
 
@@ -16,6 +17,10 @@ export function getTtlWithDuplicateValidationsRemoved(ttlCode) {
     undefined,
     GRAPHS.sourceGraph
   );
+
+  if (validations.length == 0) {
+    return ttlCode;
+  }
 
   const mappedValidationsForSubjects =
     getMappedValidationSubjectsPerNode(validations);
@@ -41,7 +46,7 @@ export function getTtlWithDuplicateValidationsRemoved(ttlCode) {
         );
         continue;
       }
-
+      hasTtlChanged = true;
       store.removeStatements([
         ...foundValidationNodeToRemove,
         ...getTriplesWithNodeAsSubject(
@@ -52,7 +57,10 @@ export function getTtlWithDuplicateValidationsRemoved(ttlCode) {
       ]);
     }
   }
-  return store.serializeDataMergedGraph(GRAPHS.sourceGraph);
+
+  return hasTtlChanged
+    ? store.serializeDataMergedGraph(GRAPHS.sourceGraph)
+    : ttlCode;
 }
 
 function getMappedValidationSubjectsPerNode(validations) {

--- a/app/utils/clean-up-ttl/remove-all-duplicate-validations.js
+++ b/app/utils/clean-up-ttl/remove-all-duplicate-validations.js
@@ -55,6 +55,10 @@ export function getTtlWithDuplicateValidationsRemoved(ttlCode) {
           GRAPHS.sourceGraph
         ),
       ]);
+      console.warn(
+        `Removed DUPLICATE validation from ttl`,
+        foundValidationNodeToRemove
+      );
     }
   }
 

--- a/app/utils/forking-store-helpers.js
+++ b/app/utils/forking-store-helpers.js
@@ -25,7 +25,13 @@ export function getDisplayTypeOfNode(node, store, graph) {
 }
 
 export function getRdfTypeOfNode(node, store, graph) {
-  return store.any(node, RDF('type'), undefined, graph);
+  const type = store.any(node, RDF('type'), undefined, graph);
+
+  if (!type) {
+    console.error(`Could not find RDF type for node`, node);
+  }
+
+  return type;
 }
 
 export function getGroupingTypeOfNode(node, store, graph) {

--- a/app/utils/validation/shape-validators/is-max-character-value-added.js
+++ b/app/utils/validation/shape-validators/is-max-character-value-added.js
@@ -14,8 +14,15 @@ export function isMaxCharacterValueAddedToMaxLengthValidation(store, graph) {
       undefined,
       graph
     );
+
     if (!maxCharactersValues.length >= 1) {
       return false;
+    }
+
+    for (const maxCharactersValue of maxCharactersValues) {
+      if (!Number(maxCharactersValue.object.value)) {
+        return false;
+      }
     }
   }
 

--- a/tests/unit/utils/clean-up-ttl/remove-all-duplicate-validations-test.js
+++ b/tests/unit/utils/clean-up-ttl/remove-all-duplicate-validations-test.js
@@ -1,0 +1,22 @@
+import { getTtlWithDuplicateValidationsRemoved } from 'frontend-form-builder/utils/clean-up-ttl/remove-all-duplicate-validations';
+import { module, test } from 'qunit';
+import basicFormWithoutValidations from './resources/basic-form-without-validations';
+
+module('Unit | Utility | Clean up ttl | Duplicate validations', function () {
+  module('Will not remove anything', function () {
+    test('no validations in ttl', function (assert) {
+      const updatedTtlCode = getTtlWithDuplicateValidationsRemoved(
+        basicFormWithoutValidations
+      );
+      assert.deepEqual(
+        stringToArray(updatedTtlCode),
+        stringToArray(basicFormWithoutValidations),
+        'The updated ttl code is the same as the original'
+      );
+    });
+  });
+});
+
+function stringToArray(string) {
+  return string.split('\n').map((line) => line.trim());
+}

--- a/tests/unit/utils/clean-up-ttl/remove-all-duplicate-validations-test.js
+++ b/tests/unit/utils/clean-up-ttl/remove-all-duplicate-validations-test.js
@@ -1,6 +1,7 @@
 import { getTtlWithDuplicateValidationsRemoved } from 'frontend-form-builder/utils/clean-up-ttl/remove-all-duplicate-validations';
 import { module, test } from 'qunit';
 import basicFormWithoutValidations from './resources/basic-form-without-validations';
+import basicFormWithOneValidationOnField from './resources/basic-form-with-one-validation-on-field';
 
 module('Unit | Utility | Clean up ttl | Duplicate validations', function () {
   module('Will not remove anything', function () {
@@ -11,6 +12,16 @@ module('Unit | Utility | Clean up ttl | Duplicate validations', function () {
       assert.deepEqual(
         stringToArray(updatedTtlCode),
         stringToArray(basicFormWithoutValidations),
+        'The updated ttl code is the same as the original'
+      );
+    });
+    test('one validation on field', function (assert) {
+      const updatedTtlCode = getTtlWithDuplicateValidationsRemoved(
+        basicFormWithOneValidationOnField
+      );
+      assert.deepEqual(
+        stringToArray(updatedTtlCode),
+        stringToArray(basicFormWithOneValidationOnField),
         'The updated ttl code is the same as the original'
       );
     });

--- a/tests/unit/utils/clean-up-ttl/remove-all-duplicate-validations-test.js
+++ b/tests/unit/utils/clean-up-ttl/remove-all-duplicate-validations-test.js
@@ -2,6 +2,8 @@ import { getTtlWithDuplicateValidationsRemoved } from 'frontend-form-builder/uti
 import { module, test } from 'qunit';
 import basicFormWithoutValidations from './resources/basic-form-without-validations';
 import basicFormWithOneValidationOnField from './resources/basic-form-with-one-validation-on-field';
+import basicFormWithDuplicateValidationOnField from './resources/basic-form-with-duplicate-validation-on-field';
+import basicFormWithDuplicateValidationOnFieldResult from './resources/basic-form-with-duplicate-validation-on-field-result';
 
 module('Unit | Utility | Clean up ttl | Duplicate validations', function () {
   module('Will not remove anything', function () {
@@ -23,6 +25,18 @@ module('Unit | Utility | Clean up ttl | Duplicate validations', function () {
         stringToArray(updatedTtlCode),
         stringToArray(basicFormWithOneValidationOnField),
         'The updated ttl code is the same as the original'
+      );
+    });
+  });
+  module('Will remove duplicates', function () {
+    test('duplicate required validation on field removed', function (assert) {
+      const updatedTtlCode = getTtlWithDuplicateValidationsRemoved(
+        basicFormWithDuplicateValidationOnField
+      );
+      assert.deepEqual(
+        stringToArray(updatedTtlCode),
+        stringToArray(basicFormWithDuplicateValidationOnFieldResult),
+        'The duplicate required validation is removed'
       );
     });
   });

--- a/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field-result.js
+++ b/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field-result.js
@@ -26,4 +26,4 @@ emb:source-node
     a form:Form, form:TopLevelForm;
     form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
     sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
-`
+`;

--- a/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field-result.js
+++ b/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field-result.js
@@ -1,0 +1,29 @@
+export default `@prefix : <#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix nodes: <http://data.lblod.info/form-data/nodes/>.
+@prefix emb: <http://ember-submission-form-fields/>.
+
+nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+    a form:Field;
+    form:displayType displayTypes:defaultInput;
+    form:validations
+            [
+                a form:RequiredConstraint;
+                form:grouping form:Bag;
+                sh:order 1;
+                sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+                sh:resultMessage "Required one"
+            ];
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
+    sh:name "Field name";
+    sh:order 2;
+    sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
+nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1
+a form:PropertyGroup; sh:name "Title"; sh:order 1 .
+emb:source-node
+    a form:Form, form:TopLevelForm;
+    form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
+`

--- a/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field.js
+++ b/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field.js
@@ -1,0 +1,36 @@
+export default `@prefix : <#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix nodes: <http://data.lblod.info/form-data/nodes/>.
+@prefix emb: <http://ember-submission-form-fields/>.
+
+nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+    a form:Field;
+    form:displayType displayTypes:defaultInput;
+    form:validations
+            [
+                a form:RequiredConstraint;
+                form:grouping form:Bag;
+                sh:order 1;
+                sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+                sh:resultMessage "Required one"
+            ],
+            [
+                a form:RequiredConstraint;
+                form:grouping form:Bag;
+                sh:order 2;
+                sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+                sh:resultMessage "Required two"
+            ];
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
+    sh:name "Field name";
+    sh:order 2;
+    sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
+nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1
+a form:PropertyGroup; sh:name "Title"; sh:order 1 .
+emb:source-node
+    a form:Form, form:TopLevelForm;
+    form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
+`

--- a/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field.js
+++ b/tests/unit/utils/clean-up-ttl/resources/basic-form-with-duplicate-validation-on-field.js
@@ -33,4 +33,4 @@ emb:source-node
     a form:Form, form:TopLevelForm;
     form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
     sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
-`
+`;

--- a/tests/unit/utils/clean-up-ttl/resources/basic-form-with-one-validation-on-field.js
+++ b/tests/unit/utils/clean-up-ttl/resources/basic-form-with-one-validation-on-field.js
@@ -1,0 +1,29 @@
+export default `@prefix : <#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix nodes: <http://data.lblod.info/form-data/nodes/>.
+@prefix emb: <http://ember-submission-form-fields/>.
+
+nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+    a form:Field;
+    form:displayType displayTypes:defaultInput;
+    form:validations
+            [
+                a form:RequiredConstraint;
+                form:grouping form:Bag;
+                sh:order 1;
+                sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+                sh:resultMessage "Required validation"
+            ];
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
+    sh:name "Field name";
+    sh:order 2;
+    sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
+nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1
+a form:PropertyGroup; sh:name "Title"; sh:order 1 .
+emb:source-node
+    a form:Form, form:TopLevelForm;
+    form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
+`;

--- a/tests/unit/utils/clean-up-ttl/resources/basic-form-without-validations.js
+++ b/tests/unit/utils/clean-up-ttl/resources/basic-form-without-validations.js
@@ -1,0 +1,21 @@
+export default `@prefix : <#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix nodes: <http://data.lblod.info/form-data/nodes/>.
+@prefix emb: <http://ember-submission-form-fields/>.
+
+nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+    a form:Field;
+    form:displayType displayTypes:defaultInput;
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
+    sh:name "Field name";
+    sh:order 2;
+    sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
+nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1
+a form:PropertyGroup; sh:name "Title"; sh:order 1 .
+emb:source-node
+    a form:Form, form:TopLevelForm;
+    form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
+`;


### PR DESCRIPTION
## ID
 [SFB-113](https://binnenland.atlassian.net/browse/SFB-113)

 ## Description

Whit the latest refactor of the validations it is possible to add duplicate validations to a field. This is only possible when adding the duplicate validation right behind each other. This means that you do not leave the `validations` tab when doing this. When you switch tabs and try to add a duplicate the components are aware and than this is not possible anymore.

In this PR i updated the form but it has to be re-rendered in the UI. This means that you will see the form re-loading when changing something in the form which is not ideal. I also added a warning notification above the validations that says that this is going to happen so the user knows that we are aware of this.

I haven't find a solution yet but we should be able to re-render the form within itself 💡 

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Go tot the validations tab  and select a field
2. Add a validation to the field
3. The form re-renders and is applied
4. When wanting to add a duplicate validation in  that same "session" this is not possible anymore

 ## Links to other PR's

 - https://github.com/lblod/frontend-form-builder/pull/74