### PR TITLE
SFB-103: character limit for name of form + edit name

### DIFF
--- a/app/components/create-form-modal.hbs
+++ b/app/components/create-form-modal.hbs
@@ -14,13 +14,20 @@
           id="input-form-name"
           @width="block"
           @error={{this.inputErrorMessage}}
+          @warning={{this.hasReachedMaxCharaters}}
           value={{this.name}}
           {{on "blur" this.handleNameChange}}
         />
-        {{#if this.inputErrorMessage}}
-          <AuHelpText @error={{true}}>{{this.inputErrorMessage}}</AuHelpText>
-        {{/if}}
-
+        <div class="input__helpTextAndCharacterCount">
+          {{#if this.inputErrorMessage}}
+            <AuHelpText @error={{true}}>{{this.inputErrorMessage}}</AuHelpText>
+          {{else}}
+            <span></span>
+          {{/if}}
+          <AuPill @size={{"small"}} class="au-u-margin-small">
+            {{this.getCharacters}}
+          </AuPill>
+        </div>
       </div>
     </div>
   </Modal.Body>

--- a/app/components/create-form-modal.hbs
+++ b/app/components/create-form-modal.hbs
@@ -1,5 +1,5 @@
 <AuModal
-  @title="Geef een naam en beschrijving"
+  @title="Geef een naam aan je formulier"
   @modalOpen={{true}}
   @closeModal={{this.closeModal}}
   as |Modal|

--- a/app/components/create-form-modal.hbs
+++ b/app/components/create-form-modal.hbs
@@ -1,13 +1,13 @@
 <AuModal
   @title="Geef een naam en beschrijving"
   @modalOpen={{true}}
-  @closeModal={{this.closeModal}} as |Modal| >
+  @closeModal={{this.closeModal}}
+  as |Modal|
+>
   <Modal.Body>
     <div class="au-o-flow">
       <div class="au-o-flow--small">
-        <AuLabel for="input-form-name"
-          @required={{true}}
-        >
+        <AuLabel for="input-form-name" @required={{true}}>
           Naam
         </AuLabel>
         <AuInput
@@ -20,26 +20,13 @@
         {{#if this.inputErrorMessage}}
           <AuHelpText @error={{true}}>{{this.inputErrorMessage}}</AuHelpText>
         {{/if}}
-        
-      </div>
-      <div class="au-o-flow--small">
-        <AuLabel for="input-form-comment">Beschrijving</AuLabel>
-        <AuTextarea
-          @width="block"
-          id="input-form-comment"
-          rows="10"
-          value={{this.description}}
-          {{on "input" this.handleDescriptionChange}}
-        />
+
       </div>
     </div>
   </Modal.Body>
   <Modal.Footer>
-      <AuButton 
-        @disabled={{this.disableSubmit}}
-        {{on "click" this.initiateForm}}
-      >
-        Bouw formulier
-      </AuButton>
+    <AuButton @disabled={{this.disableSubmit}} {{on "click" this.initiateForm}}>
+      Bouw formulier
+    </AuButton>
   </Modal.Footer>
 </AuModal>

--- a/app/components/create-form-modal.hbs
+++ b/app/components/create-form-modal.hbs
@@ -16,7 +16,7 @@
           @error={{this.inputErrorMessage}}
           @warning={{this.hasReachedMaxCharaters}}
           value={{this.name}}
-          {{on "blur" this.handleNameChange}}
+          {{on "blur" this.handleNameChange.perform}}
         />
         <div class="input__helpTextAndCharacterCount">
           {{#if this.inputErrorMessage}}
@@ -32,7 +32,12 @@
     </div>
   </Modal.Body>
   <Modal.Footer>
-    <AuButton @disabled={{this.disableSubmit}} {{on "click" this.initiateForm}}>
+    <AuButton
+      @loading={{this.handleNameChange.isRunning}}
+      @loadingMessage={{" "}}
+      @disabled={{this.disableSubmit}}
+      {{on "click" this.initiateForm}}
+    >
       Bouw formulier
     </AuButton>
   </Modal.Footer>

--- a/app/components/create-form-modal.js
+++ b/app/components/create-form-modal.js
@@ -2,7 +2,10 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { DESCRIPTION_NOT_USED_PLACEHOLDER } from '../utils/constants';
+import {
+  DESCRIPTION_NOT_USED_PLACEHOLDER,
+  NAME_INPUT_CHAR_LIMIT,
+} from '../utils/constants';
 
 export default class CreateFormModal extends Component {
   @service store;
@@ -64,14 +67,24 @@ export default class CreateFormModal extends Component {
     if (this.duplicateNames.length > 0) {
       return 'Deze naam is al eens gebruikt';
     }
+
+    if (this.name.length > NAME_INPUT_CHAR_LIMIT) {
+      return `Maximum karakters overschreden`;
+    }
+
     return false;
+  }
+
+  get getCharacters() {
+    return `Remaing characters: ${NAME_INPUT_CHAR_LIMIT - this.name.length}`;
   }
 
   get disableSubmit() {
     return (
       (this.name.trim() == '' && this.hasBeenFocused) ||
       this.duplicateNames.length > 0 ||
-      !this.hasBeenFocused
+      !this.hasBeenFocused ||
+      this.name.length > NAME_INPUT_CHAR_LIMIT
     );
   }
 }

--- a/app/components/create-form-modal.js
+++ b/app/components/create-form-modal.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { DESCRIPTION_NOT_USED_PLACEHOLDER } from '../utils/constants';
 
 export default class CreateFormModal extends Component {
   @service store;
@@ -9,7 +10,6 @@ export default class CreateFormModal extends Component {
   @service toaster;
 
   @tracked name = '';
-  @tracked description = ``;
   @tracked duplicateNames = [];
   @tracked hasBeenFocused = false;
 
@@ -30,11 +30,6 @@ export default class CreateFormModal extends Component {
   }
 
   @action
-  handleDescriptionChange(event) {
-    this.description = event.target.value;
-  }
-
-  @action
   async initiateForm() {
     const now = new Date();
 
@@ -42,11 +37,12 @@ export default class CreateFormModal extends Component {
       created: now,
       modified: now,
       label: this.name,
-      comment: this.description,
+      comment: DESCRIPTION_NOT_USED_PLACEHOLDER,
       ttlCode: '',
     });
 
     try {
+      await newForm.save();
       await newForm.save();
       this.router.transitionTo('formbuilder.edit', newForm.id);
       this.toaster.success('Formulier succesvol aangemaakt', 'Success', {

--- a/app/components/create-form-modal.js
+++ b/app/components/create-form-modal.js
@@ -69,7 +69,7 @@ export default class CreateFormModal extends Component {
     }
 
     if (this.name.length > NAME_INPUT_CHAR_LIMIT) {
-      return `Maximum karakters overschreden`;
+      return `Maximum characters exceeded`;
     }
 
     return false;

--- a/app/components/create-form-modal.js
+++ b/app/components/create-form-modal.js
@@ -23,10 +23,10 @@ export default class CreateFormModal extends Component {
   }
 
   handleNameChange = restartableTask(async (event) => {
-    this.name = event.target.value;
+    this.name = event.target.value.trim();
     this.duplicateNames = await this.store.query('generated-form', {
       filter: {
-        ':exact:label': this.name.trim(),
+        ':exact:label': this.name,
       },
     });
     this.hasBeenFocused = true;

--- a/app/components/create-form-modal.js
+++ b/app/components/create-form-modal.js
@@ -6,6 +6,7 @@ import {
   DESCRIPTION_NOT_USED_PLACEHOLDER,
   NAME_INPUT_CHAR_LIMIT,
 } from '../utils/constants';
+import { restartableTask } from 'ember-concurrency';
 
 export default class CreateFormModal extends Component {
   @service store;
@@ -21,8 +22,7 @@ export default class CreateFormModal extends Component {
     this.args.closeModal();
   }
 
-  @action
-  async handleNameChange(event) {
+  handleNameChange = restartableTask(async (event) => {
     this.name = event.target.value;
     this.duplicateNames = await this.store.query('generated-form', {
       filter: {
@@ -30,7 +30,7 @@ export default class CreateFormModal extends Component {
       },
     });
     this.hasBeenFocused = true;
-  }
+  });
 
   @action
   async initiateForm() {

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -32,15 +32,24 @@
           {{/if}}
         </div>
         <div class="titleEdit">
-          <h1 class="au-c-app-chrome__title">
-            {{@model.label}}
-          </h1>
-          <AuButton
-            @skin={{"link-secondary"}}
-            @icon={{"pencil"}}
-            @hideText={{true}}
-            {{on "click" (fn (mut this.showEditModal) true)}}
-          />
+          {{#if this.isEditingName}}
+            <AuInput
+              id="input-filelabel"
+              value={{this.formLabel}}
+              {{on "blur" this.saveUpdatedName}}
+            />
+          {{else}}
+            <h1 class="au-c-app-chrome__title">
+              {{@model.label}}
+            </h1>
+            <AuButton
+              @skin={{"link-secondary"}}
+              @icon={{"pencil"}}
+              @hideText={{true}}
+              {{on "click" (fn (mut this.isEditingName) true)}}
+            />
+          {{/if}}
+
         </div>
       </Group>
       <Group class="au-c-toolbar__group--actions">
@@ -89,28 +98,3 @@
     @onClose={{fn (mut this.showDeleteModal) false}}
   />
 {{/if}}
-
-<AuModal
-  @title="Bewerk naam en beschrijving"
-  @modalOpen={{this.showEditModal}}
-  @closeModal={{this.closeEditNameModal}}
-  as |Modal|
->
-  <Modal.Body>
-    <div class="au-o-grid au-o-grid--small">
-      <div class="au-o-grid__item au-1-1">
-        <AuLabel for="input-filelabel">
-          Naam
-        </AuLabel>
-        <AuInput
-          id="input-filelabel"
-          value={{this.formLabel}}
-          {{on "change" this.handleLabelChange}}
-        />
-      </div>
-    </div>
-  </Modal.Body>
-  <Modal.Footer>
-    <AuButton {{on "click" this.updateForm}}>Bijwerken</AuButton>
-  </Modal.Footer>
-</AuModal>

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -108,16 +108,6 @@
           {{on "change" this.handleLabelChange}}
         />
       </div>
-      <div class="au-o-grid__item au-1-1">
-        <AuLabel for="input-filecomment">Beschrijving</AuLabel>
-        <AuTextarea
-          @width="block"
-          id="input-filecomment"
-          rows="10"
-          value={{this.formComment}}
-          {{on "input" this.handleCommentChange}}
-        />
-      </div>
     </div>
   </Modal.Body>
   <Modal.Footer>

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -36,7 +36,7 @@
             <AuInput
               id="input-formName"
               value={{this.formLabel}}
-              {{on "blur" this.updateFormName}}
+              {{on "blur" this.handleFormNameChange}}
             />
             <AuButton
               @skin={{"primary"}}
@@ -48,7 +48,7 @@
               @skin={{"secondary"}}
               @icon={{"cross"}}
               @hideText={{true}}
-              {{on "click" (fn (mut this.isEditingName) false)}}
+              {{on "click" this.closeEditNameModal}}
             />
           {{else}}
             <h1 class="au-c-app-chrome__title">

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -34,9 +34,21 @@
         <div class="titleEdit">
           {{#if this.isEditingName}}
             <AuInput
-              id="input-filelabel"
+              id="input-formName"
               value={{this.formLabel}}
-              {{on "blur" this.saveUpdatedName}}
+              {{on "blur" this.updateFormName}}
+            />
+            <AuButton
+              @skin={{"primary"}}
+              @icon={{"check"}}
+              @hideText={{true}}
+              {{on "click" this.updateFormName}}
+            />
+            <AuButton
+              @skin={{"secondary"}}
+              @icon={{"cross"}}
+              @hideText={{true}}
+              {{on "click" (fn (mut this.isEditingName) false)}}
             />
           {{else}}
             <h1 class="au-c-app-chrome__title">

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -54,7 +54,7 @@ export default class ToolbarComponent extends Component {
     form.modified = new Date();
     form.ttlCode = this.formCodeManager.getTtlOfLatestVersion();
     form.label = this.formLabel;
-    form.comment = DESCRIPTION_NOT_USED_PLACEHOLDER;
+    form.comment = this.args.model.comment ?? DESCRIPTION_NOT_USED_PLACEHOLDER;
 
     try {
       await form.save();
@@ -77,6 +77,5 @@ export default class ToolbarComponent extends Component {
   closeEditNameModal() {
     this.showEditModal = false;
     this.formLabel = this.args.model.label;
-    this.formComment = DESCRIPTION_NOT_USED_PLACEHOLDER;
   }
 }

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -89,8 +89,8 @@ export default class ToolbarComponent extends Component {
 
     if (this.formLabel.length > NAME_INPUT_CHAR_LIMIT) {
       this.toaster.warning(
-        `Maxmim aantal toegelaten karakters is ${NAME_INPUT_CHAR_LIMIT}`,
-        'Karakters',
+        `The max character limit is ${NAME_INPUT_CHAR_LIMIT}`,
+        'Characters',
         {
           timeOut: 5000,
         }
@@ -111,7 +111,7 @@ export default class ToolbarComponent extends Component {
     }
 
     if (formsWithDuplicateName.length >= 1) {
-      this.toaster.error('Deze naam bestaat al', 'Error', {
+      this.toaster.error('This name already exists', 'Error', {
         timeOut: 5000,
       });
       return;

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -2,7 +2,10 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
-import { DESCRIPTION_NOT_USED_PLACEHOLDER } from '../utils/constants';
+import {
+  DESCRIPTION_NOT_USED_PLACEHOLDER,
+  NAME_INPUT_CHAR_LIMIT,
+} from '../utils/constants';
 
 export default class ToolbarComponent extends Component {
   @service store;
@@ -83,6 +86,18 @@ export default class ToolbarComponent extends Component {
   @action
   async updateFormName() {
     this.formLabel = this.formLabel.trim();
+
+    if (this.formLabel.length > NAME_INPUT_CHAR_LIMIT) {
+      this.toaster.warning(
+        `Maxmim aantal toegelaten karakters is ${NAME_INPUT_CHAR_LIMIT}`,
+        'Karakters',
+        {
+          timeOut: 5000,
+        }
+      );
+      return;
+    }
+
     const formsWithDuplicateName = await this.store.query('generated-form', {
       filter: {
         ':exact:label': this.formLabel,

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -2,8 +2,8 @@ import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+import { DESCRIPTION_NOT_USED_PLACEHOLDER } from '../utils/constants';
 
-const DESCRIPTION_PLACEHOLDER = '';
 export default class ToolbarComponent extends Component {
   @service store;
   @service router;
@@ -54,7 +54,7 @@ export default class ToolbarComponent extends Component {
     form.modified = new Date();
     form.ttlCode = this.formCodeManager.getTtlOfLatestVersion();
     form.label = this.formLabel;
-    form.comment = DESCRIPTION_PLACEHOLDER;
+    form.comment = DESCRIPTION_NOT_USED_PLACEHOLDER;
 
     try {
       await form.save();
@@ -77,6 +77,6 @@ export default class ToolbarComponent extends Component {
   closeEditNameModal() {
     this.showEditModal = false;
     this.formLabel = this.args.model.label;
-    this.formComment = DESCRIPTION_PLACEHOLDER;
+    this.formComment = DESCRIPTION_NOT_USED_PLACEHOLDER;
   }
 }

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -32,6 +32,11 @@ export default class ToolbarComponent extends Component {
   }
 
   @action
+  handleFormNameChange(event) {
+    this.formLabel = event.target.value;
+  }
+
+  @action
   async deleteForm() {
     const generatedForm = this.args.model;
     const isDeleted = await generatedForm.destroyRecord();
@@ -76,14 +81,8 @@ export default class ToolbarComponent extends Component {
   }
 
   @action
-  async updateFormName(event) {
-    if (!event.target.value) {
-      this.isEditingName = false;
-
-      return;
-    }
-
-    this.formLabel = event.target.value.trim();
+  async updateFormName() {
+    this.formLabel = this.formLabel.trim();
     const formsWithDuplicateName = await this.store.query('generated-form', {
       filter: {
         ':exact:label': this.formLabel,

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
+const DESCRIPTION_PLACEHOLDER = '';
 export default class ToolbarComponent extends Component {
   @service store;
   @service router;
@@ -13,16 +14,10 @@ export default class ToolbarComponent extends Component {
 
   @tracked showEditModal = false;
   @tracked formLabel = this.args.model.label;
-  @tracked formComment = this.args.model.comment;
 
   @action
   handleLabelChange(event) {
     this.formLabel = event.target.value;
-  }
-
-  @action
-  handleCommentChange(event) {
-    this.formComment = event.target.value;
   }
 
   @action
@@ -59,7 +54,7 @@ export default class ToolbarComponent extends Component {
     form.modified = new Date();
     form.ttlCode = this.formCodeManager.getTtlOfLatestVersion();
     form.label = this.formLabel;
-    form.comment = this.formComment;
+    form.comment = DESCRIPTION_PLACEHOLDER;
 
     try {
       await form.save();
@@ -82,6 +77,6 @@ export default class ToolbarComponent extends Component {
   closeEditNameModal() {
     this.showEditModal = false;
     this.formLabel = this.args.model.label;
-    this.formComment = this.args.model.comment;
+    this.formComment = DESCRIPTION_PLACEHOLDER;
   }
 }

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -12,13 +12,8 @@ export default class ToolbarComponent extends Component {
 
   @tracked showDeleteModal = false;
 
-  @tracked showEditModal = false;
+  @tracked isEditingName = false;
   @tracked formLabel = this.args.model.label;
-
-  @action
-  handleLabelChange(event) {
-    this.formLabel = event.target.value;
-  }
 
   @action
   saveLocally() {
@@ -33,7 +28,7 @@ export default class ToolbarComponent extends Component {
     // Click file to download then destroy link
     downloadLink.click();
     downloadLink.remove();
-    this.showEditModal = false;
+    this.isEditingName = false;
   }
 
   @action
@@ -62,7 +57,7 @@ export default class ToolbarComponent extends Component {
         timeOut: 5000,
       });
       this.formCodeManager.pinLatestVersionAsReference();
-      this.showEditModal = false;
+      this.isEditingName = false;
     } catch (err) {
       this.toaster.error('Oeps, er is iets mis gegaan', 'Error', {
         timeOut: 5000,
@@ -75,7 +70,14 @@ export default class ToolbarComponent extends Component {
 
   @action
   closeEditNameModal() {
-    this.showEditModal = false;
+    this.isEditingName = false;
     this.formLabel = this.args.model.label;
+  }
+
+  @action
+  async saveUpdatedName(event) {
+    this.formLabel = event.target.value.trim();
+    await this.updateForm();
+    this.isEditingName = false;
   }
 }

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -42,6 +42,7 @@ export default class ToolbarComponent extends Component {
 
   @action
   async updateForm() {
+    this.isEditingName = false;
     const form = await this.store.findRecord(
       'generated-form',
       this.args.model.id
@@ -75,9 +76,36 @@ export default class ToolbarComponent extends Component {
   }
 
   @action
-  async saveUpdatedName(event) {
+  async updateFormName(event) {
+    if (!event.target.value) {
+      this.isEditingName = false;
+
+      return;
+    }
+
     this.formLabel = event.target.value.trim();
-    await this.updateForm();
+    const formsWithDuplicateName = await this.store.query('generated-form', {
+      filter: {
+        ':exact:label': this.formLabel,
+      },
+    });
+
+    if (this.formLabel == this.args.model.label) {
+      this.isEditingName = false;
+
+      return;
+    }
+
+    if (formsWithDuplicateName.length >= 1) {
+      this.toaster.error('Deze naam bestaat al', 'Error', {
+        timeOut: 5000,
+      });
+      return;
+    }
+
     this.isEditingName = false;
+    await this.updateForm();
+
+    return;
   }
 }

--- a/app/styles/project/_c-app-chrome.scss
+++ b/app/styles/project/_c-app-chrome.scss
@@ -55,6 +55,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    gap: 0.5rem;
   }
 
    .au-c-app-chrome__title {

--- a/app/styles/project/c-form-builder-edit.scss
+++ b/app/styles/project/c-form-builder-edit.scss
@@ -22,3 +22,9 @@
   color: $au-gray-400;
   text-align: center;
 }
+
+.input__helpTextAndCharacterCount {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -31,9 +31,6 @@
           <c.header>
             <AuDataTableThSortable @label='Naam' @field='label' @currentSorting={{this.sort}}
               class="au-u-visible-medium-up" />
-            <AuDataTableThSortable @label='Beschrijving' @field='comment' @currentSorting={{this.sort}}
-              class="au-u-visible-medium-up" />
-
             <AuDataTableThSortable @label='Aangemaakt op' @field='created' @currentSorting={{this.sort}}
               class="au-u-visible-small-up" />
             <AuDataTableThSortable @label='Aangepast op' @field='modified' @currentSorting={{this.sort}}
@@ -44,7 +41,6 @@
             <td class="au-u-visible-medium-up">
               <AuLink @route="formbuilder.edit" @model={{generatedForm.id}} @ariaHidden={{true}}>{{generatedForm.label}}</AuLink>
             </td>
-            <td class="au-u-visible-medium-up">{{generatedForm.comment}}</td>
             <td class="au-u-visible-medium-up">{{format-date generatedForm.created}}</td>
             <td class="au-u-visible-medium-up">{{format-date-time generatedForm.modified}}</td>
             <td class="au-u-visible-medium-up">

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,0 +1,1 @@
+export const DESCRIPTION_NOT_USED_PLACEHOLDER = '';

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,1 +1,2 @@
 export const DESCRIPTION_NOT_USED_PLACEHOLDER = '';
+export const NAME_INPUT_CHAR_LIMIT = 120;


### PR DESCRIPTION
## ID
 [SFB-103](https://binnenland.atlassian.net/browse/SFB-103)

 ## Description

The description is not used when a form is created so this can be removed. When filling in a name for the form the amount of characters is infinite. Let's limit it to 120 characters.

When your form is created and you want to edit the name it pops up a modal for editing the name. As the description is removed when can directly edit the name in the toolbar.

 ## Type of change

 - [x] Refactor
 - [ ] Bug fix
 - [ ] New feature
 - [x] Breaking change
 - [ ] Other

 ## How to test

1. Create a new form test the limits of the input field
2. When the form is created edit the name of the form in the toolbar 

 ## Links to other PR's

 - /

## Attachments
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/9871bb8a-0a7a-4b3d-b3f5-a861c05f4dc3)