### PR TITLE
Serialize ember data model to turtle

### DIFF
--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -56,11 +56,13 @@ export default class FormbuilderEditController extends Controller {
 
     this.previewStore = new ForkingStore();
     // todo: could cause some lag(modifier: editor.js)
-    this.previewStore.parse(
-      this.model.conceptSchemesTtl,
-      this.model.graphs.metaGraph,
-      'text/turtle'
-    );
+    if (this.model.conceptSchemesTtl) {
+      this.previewStore.parse(
+        this.model.conceptSchemesTtl,
+        this.model.graphs.metaGraph,
+        'text/turtle'
+      );
+    }
 
     this.previewStore.parse(
       ttlCode,

--- a/app/routes/formbuilder/edit.js
+++ b/app/routes/formbuilder/edit.js
@@ -6,11 +6,10 @@ import ValidationConceptSchemeSelectorComponent from '../../components/rdf-form-
 import { getLocalFileContentAsText } from '../../utils/get-local-file-content';
 import CountryCodeConceptSchemeSelectorComponent from '../../components/rdf-form-fields/country-code-concept-scheme-selector';
 import { GRAPHS } from '../../controllers/formbuilder/edit';
-import { getConceptSchemesWithConceptsStatements } from '../../utils/get-statements-for-concept-scheme-with-concepts';
-import { getTurtleTextForStatements } from '../../utils/viewmodels/statements-to-turtle-text';
 
 export default class FormbuilderEditRoute extends Route {
   @service store;
+  @service('codelists') codelistsService;
 
   constructor() {
     super(...arguments);
@@ -23,9 +22,12 @@ export default class FormbuilderEditRoute extends Route {
         this.getGeneratedFormById(params.id),
         getLocalFileContentAsText('/forms/builder/form.ttl'),
         getLocalFileContentAsText('/forms/builder/meta.ttl'),
-        this.getConceptSchemeTurtleText() ??
-          getLocalFileContentAsText('/forms/preview/concept-schemes.ttl'),
+        getLocalFileContentAsText('/forms/preview/concept-schemes.ttl'),
       ]);
+
+    if (!this.codelistsService.findTurtleText()) {
+      console.log(`Gebruik van lokale codelijsten`);
+    }
 
     return {
       generatedForm,
@@ -44,14 +46,6 @@ export default class FormbuilderEditRoute extends Route {
 
   resetController(controller) {
     controller.reset();
-  }
-
-  async getConceptSchemeTurtleText() {
-    const statements = await getConceptSchemesWithConceptsStatements(
-      this.store
-    );
-
-    return await getTurtleTextForStatements(statements);
   }
 
   async getGeneratedFormById(generatedFormId) {

--- a/app/routes/formbuilder/edit.js
+++ b/app/routes/formbuilder/edit.js
@@ -6,6 +6,8 @@ import ValidationConceptSchemeSelectorComponent from '../../components/rdf-form-
 import { getLocalFileContentAsText } from '../../utils/get-local-file-content';
 import CountryCodeConceptSchemeSelectorComponent from '../../components/rdf-form-fields/country-code-concept-scheme-selector';
 import { GRAPHS } from '../../controllers/formbuilder/edit';
+import { getConceptSchemesWithConceptsStatements } from '../../utils/get-statements-for-concept-scheme-with-concepts';
+import { getTurtleTextForStatements } from '../../utils/viewmodels/statements-to-turtle-text';
 
 export default class FormbuilderEditRoute extends Route {
   @service store;
@@ -21,7 +23,8 @@ export default class FormbuilderEditRoute extends Route {
         this.getGeneratedFormById(params.id),
         getLocalFileContentAsText('/forms/builder/form.ttl'),
         getLocalFileContentAsText('/forms/builder/meta.ttl'),
-        getLocalFileContentAsText('/forms/preview/concept-schemes.ttl'),
+        this.getConceptSchemeTurtleText() ??
+          getLocalFileContentAsText('/forms/preview/concept-schemes.ttl'),
       ]);
 
     return {
@@ -41,6 +44,14 @@ export default class FormbuilderEditRoute extends Route {
 
   resetController(controller) {
     controller.reset();
+  }
+
+  async getConceptSchemeTurtleText() {
+    const statements = await getConceptSchemesWithConceptsStatements(
+      this.store
+    );
+
+    return await getTurtleTextForStatements(statements);
   }
 
   async getGeneratedFormById(generatedFormId) {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,10 +1,19 @@
 /* eslint-disable ember/no-mixins */
 import Route from '@ember/routing/route';
 import DataTableRouteMixin from 'ember-data-table/mixins/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class IndexRoute extends Route.extend(DataTableRouteMixin) {
   @service store;
+  @service('codelists') codelistsService;
 
   modelName = 'generated-form';
+
+  async setupController() {
+    super.setupController(...arguments);
+
+    if (this.codelistsService.findTurtleText()) {
+      await this.codelistsService.getLatest(this.store);
+    }
+  }
 }

--- a/app/services/codelists.js
+++ b/app/services/codelists.js
@@ -1,0 +1,19 @@
+import Service, { service } from '@ember/service';
+import { getConceptSchemesWithConceptsStatements } from '../utils/get-statements-for-concept-scheme-with-concepts';
+import { getTurtleTextForStatements } from '../utils/viewmodels/statements-to-turtle-text';
+
+export default class CodelistsService extends Service {
+  @service store;
+  statements = [];
+  turtleText = null;
+
+  async getLatest() {
+    this.statements = await getConceptSchemesWithConceptsStatements(this.store);
+    this.turtleText = await getTurtleTextForStatements(this.statements);
+    console.log(`Laatste codelijsten opgehaald`);
+  }
+
+  async findTurtleText() {
+    return this.turtleText;
+  }
+}

--- a/app/utils/get-statements-for-concept-scheme-with-concepts.js
+++ b/app/utils/get-statements-for-concept-scheme-with-concepts.js
@@ -1,0 +1,29 @@
+import { NamedNode } from 'rdflib';
+import { conceptAsStatements } from './viewmodels/concept-as-statements';
+import { conceptSchemeAsStatements } from './viewmodels/concept-scheme-as-statements';
+
+export async function getConceptSchemesWithConceptsStatements(store) {
+  const conceptSchemes = await store.query('concept-scheme', {
+    include: 'concepts',
+    page: {
+      size: 999,
+    },
+  });
+
+  const conceptSchemeStatements = conceptSchemes.map((model) =>
+    conceptSchemeAsStatements(model)
+  );
+
+  const conceptStatements = [];
+  for (const conceptScheme of conceptSchemes) {
+    const conceptSchemeSubject = new NamedNode(conceptScheme.uri);
+
+    const conceptModels = new Array(...(await conceptScheme.concepts));
+    conceptStatements.push(
+      ...conceptModels.map((model) =>
+        conceptAsStatements(model, conceptSchemeSubject)
+      )
+    );
+  }
+  return [...conceptSchemeStatements, ...conceptStatements];
+}

--- a/app/utils/rdflib.js
+++ b/app/utils/rdflib.js
@@ -5,3 +5,4 @@ export const RDF = new Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#');
 export const FORM = new Namespace('http://lblod.data.gift/vocabularies/forms/');
 export const SH = new Namespace('http://www.w3.org/ns/shacl#');
 export const EXT = new Namespace('http://mu.semte.ch/vocabularies/ext/');
+export const SKOS = new Namespace('http://www.w3.org/2004/02/skos/core#');

--- a/app/utils/viewmodels/concept-as-statements.js
+++ b/app/utils/viewmodels/concept-as-statements.js
@@ -1,0 +1,23 @@
+import { Literal, NamedNode, Statement } from 'rdflib';
+import { GRAPHS } from '../../controllers/formbuilder/edit';
+import { RDF, SKOS } from '../rdflib';
+
+export function conceptAsStatements(model, conceptSchemeSubject) {
+  const subject = new NamedNode(model.uri);
+
+  return [
+    new Statement(subject, RDF('type'), SKOS('Concept'), GRAPHS.sourceGraph),
+    new Statement(
+      subject,
+      SKOS('inScheme'),
+      conceptSchemeSubject,
+      GRAPHS.sourceGraph
+    ),
+    new Statement(
+      subject,
+      SKOS('prefLabel'),
+      new Literal(model.label),
+      GRAPHS.sourceGraph
+    ),
+  ];
+}

--- a/app/utils/viewmodels/concept-scheme-as-statements.js
+++ b/app/utils/viewmodels/concept-scheme-as-statements.js
@@ -1,0 +1,22 @@
+import { Literal, NamedNode, Statement } from 'rdflib';
+import { GRAPHS } from '../../controllers/formbuilder/edit';
+import { RDF, SKOS } from '../rdflib';
+
+export function conceptSchemeAsStatements(model) {
+  const subject = new NamedNode(model.uri);
+
+  return [
+    new Statement(
+      subject,
+      RDF('type'),
+      SKOS('ConceptScheme'),
+      GRAPHS.sourceGraph
+    ),
+    new Statement(
+      subject,
+      SKOS('prefLabel'),
+      new Literal(model.label),
+      GRAPHS.sourceGraph
+    ),
+  ];
+}

--- a/app/utils/viewmodels/statements-to-turtle-text.js
+++ b/app/utils/viewmodels/statements-to-turtle-text.js
@@ -1,0 +1,22 @@
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { GRAPHS } from '../../controllers/formbuilder/edit';
+
+export async function getTurtleTextForStatements(statements) {
+  return new Promise((resolve) => {
+    const store = new ForkingStore();
+    try {
+      for (const statement of statements) {
+        if (statement.length) {
+          store.addAll(statement);
+          continue;
+        }
+        store.addAll([statement]);
+      }
+    } catch (error) {
+      console.error(`Could not parse statements in the graph`, error);
+      resolve(null);
+    }
+
+    resolve(store.serializeDataMergedGraph(GRAPHS.sourceGraph));
+  });
+}

--- a/tests/unit/services/codelists-test.js
+++ b/tests/unit/services/codelists-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-form-builder/tests/helpers';
+
+module('Unit | Service | codelists', function (hooks) {
+  setupTest(hooks);
+
+  // TODO: Replace this with your real tests.
+  test('it exists', function (assert) {
+    let service = this.owner.lookup('service:codelists');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
All concept schemes that can be used in the form-builder come from the database but for the preview, these concept-schemes and concepts are stored in a static file. This means that when creating new concept schemes we do not have the latest data to show in our preview which results in an empty list and confusion for our users.

In this PR I created a service that will get all the latest concept schemes with their concepts from the database when going to the form overview page. If the service returns null for the TTL of the concept-schemes it will use the local file in the form-builder public folder.