### PR TITLE
SFB-121: Remove the form:options if the field displayType does not support it

### DIFF
--- a/app/controllers/formbuilder/edit/code.js
+++ b/app/controllers/formbuilder/edit/code.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
 import { tracked } from '@glimmer/tracking';
 import { ForkingStore } from '@lblod/ember-submission-form-fields';
-import { getTtlWithUnReferencedSubjectsRemoved } from '../../../utils/clean-up-ttl/remove-unreferenced-subjects';
+import { cleanupTtlcode } from '../../../utils/clean-up-ttl/clean-up-ttl-code';
 
 export default class FormbuilderEditCodeController extends Controller {
   @service('form-code-manager') formCodeManager;
@@ -14,10 +14,11 @@ export default class FormbuilderEditCodeController extends Controller {
   @tracked formCodeUpdates;
 
   setup() {
-    const updatedFormCode = getTtlWithUnReferencedSubjectsRemoved(
+    const updatedFormCode = cleanupTtlcode(
       this.formCodeManager.getTtlOfLatestVersion(),
       this.toaster
     );
+
     this.formCode = updatedFormCode;
     this.formCodeUpdates = this.formCode;
     this.model.handleCodeChange(this.formCode);

--- a/app/controllers/formbuilder/edit/configuration.js
+++ b/app/controllers/formbuilder/edit/configuration.js
@@ -25,7 +25,6 @@ export default class FormbuilderConfigurationController extends Controller {
   updateFieldOptions(scheme) {
     const conceptSchemeConfig = {
       conceptScheme: scheme.uri,
-      searchEnabled: true,
     };
     const existingOptionsOnField = this.builderStore.match(
       scheme.field.subject,

--- a/app/helpers/is-display-type-with-options.js
+++ b/app/helpers/is-display-type-with-options.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { DISPLAY } from '../utils/rdflib';
+import { canDisplayTypeHaveFormOptions } from '../utils/can-display-type-have-form-options';
 
 export default helper(function isDisplayTypeWithOptions(displayType) {
   const itemDisplayType = [...displayType][0];
@@ -8,16 +8,5 @@ export default helper(function isDisplayTypeWithOptions(displayType) {
     return false;
   }
 
-  const selectorDisplayTypes = [
-    DISPLAY('conceptSchemeMultiSelectCheckboxes').value,
-    DISPLAY('conceptSchemeMultiSelector').value,
-    DISPLAY('conceptSchemeRadioButtons').value,
-    DISPLAY('conceptSchemeSelector').value,
-  ];
-
-  if (selectorDisplayTypes.includes(itemDisplayType.value)) {
-    return true;
-  }
-
-  return false;
+  return canDisplayTypeHaveFormOptions(itemDisplayType);
 });

--- a/app/utils/can-display-type-have-form-options.js
+++ b/app/utils/can-display-type-have-form-options.js
@@ -1,0 +1,20 @@
+import { DISPLAY } from './rdflib';
+
+export function canDisplayTypeHaveFormOptions(displayType) {
+  if (!displayType) {
+    return false;
+  }
+
+  const selectorDisplayTypes = [
+    DISPLAY('conceptSchemeMultiSelectCheckboxes').value,
+    DISPLAY('conceptSchemeMultiSelector').value,
+    DISPLAY('conceptSchemeRadioButtons').value,
+    DISPLAY('conceptSchemeSelector').value,
+  ];
+
+  if (selectorDisplayTypes.includes(displayType.value)) {
+    return true;
+  }
+
+  return false;
+}

--- a/app/utils/clean-up-ttl/clean-up-field-options.js
+++ b/app/utils/clean-up-ttl/clean-up-field-options.js
@@ -1,0 +1,75 @@
+import { GRAPHS } from '../../controllers/formbuilder/edit';
+import { ForkingStore } from '@lblod/ember-submission-form-fields';
+import { FORM, RDF } from '../rdflib';
+import { canDisplayTypeHaveFormOptions } from '../can-display-type-have-form-options';
+import { Statement } from 'rdflib';
+
+export function getTtlWithCleanUpFieldOptions(ttlCode) {
+  return removeConceptschemeFromFieldOptions(ttlCode);
+}
+
+function removeConceptschemeFromFieldOptions(ttlCode) {
+  let hasTtlChanged = false;
+  const store = new ForkingStore();
+  store.parse(ttlCode, GRAPHS.sourceGraph, 'text/turtle');
+
+  const fieldSubjects = store
+    .match(undefined, RDF('type'), FORM('Field'), GRAPHS.sourceGraph)
+    .map((triple) => triple.subject);
+
+  for (const subject of fieldSubjects) {
+    const displayType = store.any(
+      subject,
+      FORM('displayType'),
+      undefined,
+      GRAPHS.sourceGraph
+    );
+
+    if (canDisplayTypeHaveFormOptions(displayType)) {
+      continue;
+    }
+
+    const formOptions = store.any(
+      subject,
+      FORM('options'),
+      undefined,
+      GRAPHS.sourceGraph
+    );
+
+    if (!formOptions) {
+      return;
+    }
+
+    let formOptionsAsJson = {};
+    try {
+      formOptionsAsJson = JSON.parse(formOptions);
+    } catch (error) {
+      console.error(`Kan de form:options niet parse naar json`, error);
+      continue;
+    }
+
+    if (formOptionsAsJson['conceptScheme']) {
+      hasTtlChanged = true;
+      delete formOptionsAsJson.conceptScheme;
+    }
+
+    store.removeStatements([
+      new Statement(subject, FORM('options'), formOptions, GRAPHS.sourceGraph),
+    ]);
+
+    if (Object.keys(formOptionsAsJson).length !== 0) {
+      store.addAll([
+        new Statement(
+          subject,
+          FORM('options'),
+          JSON.stringify(formOptionsAsJson),
+          GRAPHS.sourceGraph
+        ),
+      ]);
+    }
+  }
+
+  return hasTtlChanged
+    ? store.serializeDataMergedGraph(GRAPHS.sourceGraph)
+    : ttlCode;
+}

--- a/app/utils/clean-up-ttl/clean-up-field-options.js
+++ b/app/utils/clean-up-ttl/clean-up-field-options.js
@@ -37,7 +37,7 @@ function removeConceptschemeFromFieldOptions(ttlCode) {
     );
 
     if (!formOptions) {
-      return;
+      continue;
     }
 
     let formOptionsAsJson = {};

--- a/app/utils/clean-up-ttl/clean-up-ttl-code.js
+++ b/app/utils/clean-up-ttl/clean-up-ttl-code.js
@@ -1,0 +1,10 @@
+import { getTtlWithCleanUpFieldOptions } from './clean-up-field-options';
+import { getTtlWithUnReferencedSubjectsRemoved } from './remove-unreferenced-subjects';
+
+export function cleanupTtlcode(ttlCode, toasterService) {
+  let updatedTtl = getTtlWithUnReferencedSubjectsRemoved(
+    ttlCode,
+    toasterService
+  );
+  return getTtlWithCleanUpFieldOptions(updatedTtl);
+}

--- a/app/utils/clean-up-ttl/clean-up-ttl-code.js
+++ b/app/utils/clean-up-ttl/clean-up-ttl-code.js
@@ -6,5 +6,6 @@ export function cleanupTtlcode(ttlCode, toasterService) {
     ttlCode,
     toasterService
   );
+
   return getTtlWithCleanUpFieldOptions(updatedTtl);
 }


### PR DESCRIPTION
## ID
 [SFB-121](https://binnenland.atlassian.net/browse/SFB-121)

 ## Description

When adding a codelist to a field the data is updated that the field will have form:options. These options remained when switching the displayType to a not selector displayType. Now when people go to the code editor the field options are cleanedup.

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Create a field with a selector displayType
2. Add options to the selector
3. Go to the builder tab and change the displayType to defaultInput for example
4. Go to the code editor and see if the conceptscheme option is still available on the form:options


 ## Links to other PR's

 - /