### PR TITLE
Refactor: duplicate methods for sorting

### DIFF
--- a/app/components/concept-scheme-uri-selector.js
+++ b/app/components/concept-scheme-uri-selector.js
@@ -3,6 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
 import { PAGE_SIZE_TO_GET_ALL } from '../utils/constants';
+import { sortObjectsOnProperty } from '../utils/sort-object-on-property';
 
 export default class ConceptSchemeUriSelectorComponent extends Component {
   @service store;
@@ -55,7 +56,7 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
       },
     });
 
-    this.options = this.getSortedOptions(conceptSchemes);
+    this.options = sortObjectsOnProperty([...conceptSchemes], 'label');
 
     if (this.args.forField) {
       await this.loadSelected();
@@ -81,17 +82,5 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
   async setSelected(value) {
     this.selected = value;
     await this.update();
-  }
-
-  getSortedOptions(conceptSchemeModels) {
-    return [...conceptSchemeModels].sort(function (a, b) {
-      if (a.label < b.label) {
-        return -1;
-      }
-      if (a.label > b.label) {
-        return 1;
-      }
-      return 0;
-    });
   }
 }

--- a/app/components/rdf-form-fields/country-code-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/country-code-concept-scheme-selector.js
@@ -6,12 +6,7 @@ import { SKOS, updateSimpleFormValue } from '@lblod/submission-form-helpers';
 import { Statement, namedNode } from 'rdflib';
 import { FORM } from '@lblod/submission-form-helpers';
 import { getPrefLabelOfNode } from '../../utils/forking-store-helpers';
-
-function byLabel(a, b) {
-  const textA = a.label.toUpperCase();
-  const textB = b.label.toUpperCase();
-  return textA < textB ? -1 : textA > textB ? 1 : 0;
-}
+import { sortObjectsOnProperty } from '../../utils/sort-object-on-property';
 
 export default class CountryCodeConceptSchemeSelectorComponent extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
@@ -35,7 +30,7 @@ export default class CountryCodeConceptSchemeSelectorComponent extends InputFiel
       this.searchEnabled = fieldOptions.searchEnabled;
     }
 
-    this.countryCodeOptions = this.args.formStore
+    const codeOptions = this.args.formStore
       .match(undefined, SKOS('inScheme'), conceptScheme, metaGraph)
       .map((t) => {
         const label = getPrefLabelOfNode(
@@ -46,7 +41,8 @@ export default class CountryCodeConceptSchemeSelectorComponent extends InputFiel
 
         return { subject: t.subject, label: label && label.value };
       });
-    this.countryCodeOptions.sort(byLabel);
+
+    this.countryCodeOptions = sortObjectsOnProperty(codeOptions, 'label');
   }
 
   loadSelectedCountryCodeOption() {

--- a/app/components/rdf-form-fields/property-group-selector.js
+++ b/app/components/rdf-form-fields/property-group-selector.js
@@ -9,12 +9,7 @@ import {
   updateSimpleFormValue,
 } from '@lblod/submission-form-helpers';
 import { namedNode } from 'rdflib';
-
-function byLabel(a, b) {
-  const textA = a.label?.toUpperCase();
-  const textB = b.label?.toUpperCase();
-  return textA < textB ? -1 : textA > textB ? 1 : 0;
-}
+import { sortObjectsOnProperty } from '../../utils/sort-object-on-property';
 
 export default class PropertyGroupSelector extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
@@ -52,7 +47,7 @@ export default class PropertyGroupSelector extends InputFieldComponent {
       return option.label;
     });
 
-    this.options = optionsWithALabel.sort(byLabel);
+    this.options = sortObjectsOnProperty(optionsWithALabel, 'label');
   }
 
   loadProvidedValue() {

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -85,7 +85,8 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
     });
     this.validationTypeOptions = sortObjectsOnProperty(
       filteredOptions,
-      'label'
+      'label',
+      false
     );
   }
 

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -17,12 +17,7 @@ import {
 import { showErrorToasterMessage } from '../../utils/toaster-message-helper';
 import { getGroupingTypeForValidation } from '../../utils/validation/get-grouping-type-for-validation';
 import { getDefaultErrorMessageForValidation } from '../../utils/validation/get-default-error-message-for-validation';
-
-function byLabel(a, b) {
-  const textA = a.label.toUpperCase();
-  const textB = b.label.toUpperCase();
-  return textA < textB ? -1 : textA > textB ? 1 : 0;
-}
+import { sortObjectsOnProperty } from '../../utils/sort-object-on-property';
 
 export default class ValidationConceptSchemeSelectorComponent extends InputFieldComponent {
   inputId = 'select-' + guidFor(this);
@@ -83,12 +78,15 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
         return { subject: t.subject, label: label && label.value };
       });
 
-    this.validationTypeOptions = allOptions.filter((option) => {
+    const filteredOptions = allOptions.filter((option) => {
       return conceptOptions
         .map((concept) => concept.value)
         .includes(option.subject.value);
     });
-    this.validationTypeOptions.sort(byLabel);
+    this.validationTypeOptions = sortObjectsOnProperty(
+      filteredOptions,
+      'label'
+    );
   }
 
   loadProvidedValidationType() {

--- a/app/utils/sort-object-on-property.js
+++ b/app/utils/sort-object-on-property.js
@@ -1,4 +1,8 @@
-export function sortObjectsOnProperty(arrayOfObjects, property) {
+export function sortObjectsOnProperty(
+  arrayOfObjects,
+  property,
+  sortAscending = true
+) {
   return arrayOfObjects.sort((a, b) => {
     if (!a[property]) {
       console.error(`Object heeft geen attribuut '${property}'`, a);
@@ -12,10 +16,10 @@ export function sortObjectsOnProperty(arrayOfObjects, property) {
       comparison = b[property];
 
     if (value < comparison) {
-      return -1;
+      return sortAscending ? -1 : 1;
     }
     if (value > comparison) {
-      return 1;
+      return sortAscending ? 1 : -1;
     }
     return 0;
   });

--- a/tests/unit/utils/sort-object-on-property-test.js
+++ b/tests/unit/utils/sort-object-on-property-test.js
@@ -1,0 +1,92 @@
+import { sortObjectsOnProperty } from 'frontend-form-builder/utils/sort-object-on-property';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | sortObjectsOnProperty', function () {
+  module('can sort', function () {
+    test('ascending on property label', function (assert) {
+      const objects = [
+        {
+          label: 'z',
+        },
+        {
+          label: 'n',
+        },
+        {
+          label: 'a',
+        },
+      ];
+
+      const sortedObjects = [
+        {
+          label: 'a',
+        },
+        {
+          label: 'n',
+        },
+        {
+          label: 'z',
+        },
+      ];
+
+      assert.deepEqual(sortObjectsOnProperty(objects, 'label'), sortedObjects);
+    });
+    test('descending on property label', function (assert) {
+      const sortAscending = false;
+      const objects = [
+        {
+          label: 'a',
+        },
+        {
+          label: 'n',
+        },
+        {
+          label: 'z',
+        },
+      ];
+
+      const sortedObjects = [
+        {
+          label: 'z',
+        },
+        {
+          label: 'n',
+        },
+        {
+          label: 'a',
+        },
+      ];
+
+      assert.deepEqual(
+        sortObjectsOnProperty(objects, 'label', sortAscending),
+        sortedObjects
+      );
+    });
+    test('ascending on property with mixed capital letter', function (assert) {
+      const objects = [
+        {
+          label: 'z',
+        },
+        {
+          label: 'A',
+        },
+        {
+          label: 'a',
+        },
+      ];
+
+      const sortedObjects = [
+        {
+          label: 'A',
+        },
+        {
+          label: 'a',
+        },
+        {
+          label: 'z',
+        },
+      ];
+
+      assert.deepEqual(sortObjectsOnProperty(objects, 'label'), sortedObjects);
+    });
+  });
+});


### PR DESCRIPTION
## Issue and fix

In many files  a sorting method is created at the top of the file. This method was the same for a lot of files. Since we created a `sort objects on property` util method we can use that one so we do not have to redefine the `byLabel` method in each file.

```js
function byLabel(a, b) {
  const textA = a.label.toUpperCase();
  const textB = b.label.toUpperCase();
  return textA < textB ? -1 : textA > textB ? 1 : 0;
}
```

## Test
1. all items should be sorted ascernding
2. except for the validation type options I hyave set these on descending so the "Verplicht" options what is used the most is at the top of the list
3. Created a basic unit test that will show that we can sort on property `label` _ascending_ and _descending_.

