### PR TITLE
feat: add feature flag for create codelist button

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -12,6 +12,7 @@ Router.map(function () {
   });
   this.route('codelijsten', function () {
     // commented to prevent users to still create a new codelist by changing the url
+    // feature flag: CAN_CREATE_OWN_CODELIST
     // this.route('new');
     this.route('edit', { path: '/:id/edit' });
   });

--- a/app/router.js
+++ b/app/router.js
@@ -11,7 +11,8 @@ Router.map(function () {
     this.route('playground');
   });
   this.route('codelijsten', function () {
-    this.route('new');
+    // commented to prevent users to still create a new codelist by changing the url
+    // this.route('new');
     this.route('edit', { path: '/:id/edit' });
   });
   this.route('formbuilder', function () {

--- a/app/templates/codelijsten/index.hbs
+++ b/app/templates/codelijsten/index.hbs
@@ -26,12 +26,14 @@
   </div>
   <div class="au-c-toolbar__group">
     <AuButtonGroup>
-      <AuLink
-        @route="codelijsten.new"
-        @skin="button"
-        @icon="plus"
-        @iconAlignment="left"
-      >{{t "codelists.createCodelist"}}</AuLink>
+      {{#if this.features.CAN_CREATE_OWN_CODELIST}}
+        <AuLink
+          @route="codelijsten.new"
+          @skin="button"
+          @icon="plus"
+          @iconAlignment="left"
+        >{{t "codelists.createCodelist"}}</AuLink>
+      {{/if}}
     </AuButtonGroup>
   </div>
 </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,6 +21,7 @@ module.exports = function (environment) {
     featureFlags: {
       SHOW_ORIGNAL_CODELIST_PAGE: false,
       USE_DEFAULT_ERROR_MESSAGE: false, // when switching uncomment help text error message public/forms/validation/form.ttl
+      CAN_CREATE_OWN_CODELIST: false,
     },
   };
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -21,7 +21,7 @@ module.exports = function (environment) {
     featureFlags: {
       SHOW_ORIGNAL_CODELIST_PAGE: false,
       USE_DEFAULT_ERROR_MESSAGE: false, // when switching uncomment help text error message public/forms/validation/form.ttl
-      CAN_CREATE_OWN_CODELIST: false,
+      CAN_CREATE_OWN_CODELIST: false, // when switching to true also uncomment the `codelijsten/new` route in `router.js`
     },
   };
 


### PR DESCRIPTION
## Issue

Users can make their own codelists but those itemst will not be visible in the dropdown when they want to assign a codelist to a field. 

## Fix

Put the create button behind a feature flag `CAN_CREATE_OWN_CODELIST` and set it to `false`.

## Test

- Can you create a new codelists?