### PR TITLE
SFB-122:double error messages

### DIFF
--- a/app/components/rdf-form-fields/error-message-input-field.hbs
+++ b/app/components/rdf-form-fields/error-message-input-field.hbs
@@ -3,11 +3,13 @@
   >
     {{@field.label}}
 </AuLabel>
+
 <AuInput
   @error={{this.hasErrors}}
-  @disabled={{@show}}
+  @disabled={{this.useDefaultMessage}}
   @width={{if @inTable "block"}}
   id={{this.inputId}}
   value={{this.value}}
   {{on "blur" this.updateValue}}
 />
+<AuToggleSwitch @onChange={{this.toggle}}>{{this.toggleMessage}}</AuToggleSwitch>

--- a/app/components/rdf-form-fields/error-message-input-field.hbs
+++ b/app/components/rdf-form-fields/error-message-input-field.hbs
@@ -12,4 +12,6 @@
   value={{this.value}}
   {{on "blur" this.updateValue}}
 />
-<AuToggleSwitch @onChange={{this.toggle}}>{{this.toggleMessage}}</AuToggleSwitch>
+{{#if this.features.USE_DEFAULT_ERROR_MESSAGE}}
+  <AuToggleSwitch @onChange={{this.toggle}}>{{this.toggleMessage}}</AuToggleSwitch>
+{{/if}}

--- a/app/components/rdf-form-fields/error-message-input-field.hbs
+++ b/app/components/rdf-form-fields/error-message-input-field.hbs
@@ -13,5 +13,5 @@
   {{on "blur" this.updateValue}}
 />
 {{#if this.features.USE_DEFAULT_ERROR_MESSAGE}}
-  <AuToggleSwitch @onChange={{this.toggle}}>{{this.toggleMessage}}</AuToggleSwitch>
+  <AuToggleSwitch @onChange={{this.toggle}} @checked={{this.useDefaultMessage}}>{{this.toggleMessage}}</AuToggleSwitch>
 {{/if}}

--- a/app/components/rdf-form-fields/error-message-input-field.hbs
+++ b/app/components/rdf-form-fields/error-message-input-field.hbs
@@ -1,0 +1,13 @@
+<AuLabel
+    for={{this.inputId}}
+  >
+    {{@field.label}}
+</AuLabel>
+<AuInput
+  @error={{this.hasErrors}}
+  @disabled={{@show}}
+  @width={{if @inTable "block"}}
+  id={{this.inputId}}
+  value={{this.value}}
+  {{on "blur" this.updateValue}}
+/>

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -28,9 +28,9 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
         this.value,
         this.storeOptions.sourceGraph
       );
-      this.removeOldMessage();
       this.args.formStore.addAll([messageToForm]);
     }
+    this.removeOldMessage();
   }
 
   @action

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -2,13 +2,16 @@ import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/compo
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
-import { SHACL } from '@lblod/submission-form-helpers';
+import { SHACL, RDF } from '@lblod/submission-form-helpers';
 import { Statement } from 'rdflib';
+import { getDefaultErrorMessageForValidation } from '../../utils/validation/get-default-error-message-for-validation';
+
 
 export default class ErrorMessageInputFieldComponent extends SimpleInputFieldComponent {
   inputId = 'select-' + guidFor(this);
 
   @tracked value;
+  @tracked useDefaultMessage = false;
 
   constructor() {
     super(...arguments);
@@ -16,31 +19,8 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
 
   @action
   updateValue(e) {
-    let newErrorMessage = e.target.value.trim();
-    const oldErrorMessage = this.args.formStore.match(
-      this.storeOptions.sourceNode,
-      SHACL('resultMessage'),
-      undefined,
-      this.storeOptions.sourceGraph
-    );
-    if (newErrorMessage.length > 0) {
-      this.value = newErrorMessage;
-
-      if (oldErrorMessage) {
-        this.args.formStore.removeStatements(oldErrorMessage);
-      }
-    } else {
-      const errorMessageInForm = this.args.formStore.any(
-        this.storeOptions.sourceNode,
-        SHACL('resultMessage'),
-        undefined,
-        this.storeOptions.sourceGraph
-      );
-      if (errorMessageInForm) {
-        this.value = errorMessageInForm;
-      }
-    }
-
+    this.value = e.target.value.trim();
+   
     if (this.value) {
       const messageToForm = new Statement(
         this.storeOptions.sourceNode,
@@ -48,7 +28,76 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
         this.value,
         this.storeOptions.sourceGraph
       );
+      this.removeOldMessage();
       this.args.formStore.addAll([messageToForm]);
+    }
+  }
+
+  @action
+  toggle() {
+    this.useDefaultMessage = !this.useDefaultMessage;
+    this.removeOldMessage();
+    if (this.useDefaultMessage) {
+      const selectedValidationType= this.args.formStore.any(
+        this.storeOptions.sourceNode,
+        RDF('type'),
+        undefined,
+        this.storeOptions.sourceGraph
+      );
+
+      const defaultErrorMessage = getDefaultErrorMessageForValidation(
+        selectedValidationType,
+        this.storeOptions.store,
+        this.storeOptions.metaGraph
+      );
+
+      if (defaultErrorMessage) {
+        this.value = defaultErrorMessage;
+        const statement =
+          this.createStatementForDefaultErrorMessage(
+            this.storeOptions.sourceNode,
+            defaultErrorMessage,
+            this.storeOptions.sourceGraph
+          );
+          this.storeOptions.store.addAll([statement]);
+      }
+    } else {
+      this.value = '';
+    }
+  }
+
+  removeOldMessage() {
+    const oldErrorMessage = this.args.formStore.match(
+      this.storeOptions.sourceNode,
+      SHACL('resultMessage'),
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+    if (oldErrorMessage) {
+      this.args.formStore.removeStatements(oldErrorMessage);
+    }
+  }
+
+  createStatementForDefaultErrorMessage(
+    sourceNode,
+    defaultErrorMessage,
+    graph
+  ) {
+    if (defaultErrorMessage) {
+      return new Statement(
+        sourceNode,
+        SHACL('resultMessage'),
+        defaultErrorMessage,
+        graph
+      );
+    }
+  }
+
+  get toggleMessage() {
+    if (this.useDefaultMessage) {
+      return 'Toggle om een aangepaste foutmelding te gebruiken.'
+    } else {
+      return 'Toggle om een standaard foutmelding te gebruiken.'
     }
   }
 }

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -16,6 +16,7 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
 
   constructor() {
     super(...arguments);
+    this.checkForDefaultMessages();
   }
 
   @action
@@ -28,9 +29,11 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
         this.value,
         this.storeOptions.sourceGraph
       );
+      this.removeOldMessage();
       this.args.formStore.addAll([messageToForm]);
+    } else {
+      this.removeOldMessage();
     }
-    this.removeOldMessage();
   }
 
   @action
@@ -90,6 +93,18 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
         defaultErrorMessage,
         graph
       );
+    }
+  }
+
+  checkForDefaultMessages() {
+    const defaultMessages = this.storeOptions.store.match(
+      undefined,
+      SHACL('resultMessage'),
+      undefined,
+      this.storeOptions.metaGraph
+    ).map(item => item.object.value);
+    if (defaultMessages.includes(this.value)) {
+      this.useDefaultMessage = true;
     }
   }
 

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -1,15 +1,60 @@
-import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { action } from '@ember/object';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
+import { SHACL } from '@lblod/submission-form-helpers';
+import { Statement } from 'rdflib';
 
-export default class ErrorMessageInputFieldComponent extends InputFieldComponent {
+
+export default class ErrorMessageInputFieldComponent extends SimpleInputFieldComponent {
   inputId = 'select-' + guidFor(this);
 
-  @tracked value = 25;
+  @tracked value;
+
+  constructor() {
+    super(...arguments);
+    this.loadValue();
+  }
+
+  loadValue() {
+    const test = this.args.formStore.any(
+      this.storeOptions.sourceNode,
+      SHACL('resultMessage'),
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+    if (test) {
+      this.value = test;
+    }
+  }
   
   @action
-  updateValue() {
+  updateValue(e) {
+    this.loadValue();
 
+    this.value = e.target.value.trim();
+
+    const oldValue = this.args.formStore.match(
+      this.storeOptions.sourceNode,
+      SHACL('resultMessage'),
+      undefined,
+      this.storeOptions.sourceGraph
+    );
+
+    if (this.value.length>0) {
+    this.args.formStore.removeStatements(oldValue);
+    super.updateValidations();
+    }
+
+    if(this.value) {
+      const statement = new Statement(
+        this.storeOptions.sourceNode,
+        SHACL('resultMessage'),
+        this.value,
+        this.storeOptions.sourceGraph
+      );
+      this.args.formStore.addAll([statement]);
+      super.updateValue(this.value);
+    }
   }
 }

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -6,7 +6,6 @@ import { SHACL, RDF } from '@lblod/submission-form-helpers';
 import { Statement } from 'rdflib';
 import { getDefaultErrorMessageForValidation } from '../../utils/validation/get-default-error-message-for-validation';
 
-
 export default class ErrorMessageInputFieldComponent extends SimpleInputFieldComponent {
   inputId = 'select-' + guidFor(this);
 
@@ -20,7 +19,6 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
   @action
   updateValue(e) {
     this.value = e.target.value.trim();
-   
     if (this.value) {
       const messageToForm = new Statement(
         this.storeOptions.sourceNode,
@@ -38,28 +36,28 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
     this.useDefaultMessage = !this.useDefaultMessage;
     this.removeOldMessage();
     if (this.useDefaultMessage) {
-      const selectedValidationType= this.args.formStore.any(
+      const selectedValidationType = this.args.formStore.any(
         this.storeOptions.sourceNode,
         RDF('type'),
         undefined,
         this.storeOptions.sourceGraph
       );
+      if (selectedValidationType) {
+        const defaultErrorMessage = getDefaultErrorMessageForValidation(
+          selectedValidationType,
+          this.storeOptions.store,
+          this.storeOptions.metaGraph
+        );
 
-      const defaultErrorMessage = getDefaultErrorMessageForValidation(
-        selectedValidationType,
-        this.storeOptions.store,
-        this.storeOptions.metaGraph
-      );
-
-      if (defaultErrorMessage) {
-        this.value = defaultErrorMessage;
-        const statement =
-          this.createStatementForDefaultErrorMessage(
+        if (defaultErrorMessage) {
+          this.value = defaultErrorMessage;
+          const statement = this.createStatementForDefaultErrorMessage(
             this.storeOptions.sourceNode,
             defaultErrorMessage,
             this.storeOptions.sourceGraph
           );
           this.storeOptions.store.addAll([statement]);
+        }
       }
     } else {
       this.value = '';
@@ -95,9 +93,9 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
 
   get toggleMessage() {
     if (this.useDefaultMessage) {
-      return 'Toggle om een aangepaste foutmelding te gebruiken.'
+      return 'Toggle om een aangepaste foutmelding te gebruiken.';
     } else {
-      return 'Toggle om een standaard foutmelding te gebruiken.'
+      return 'Toggle om een standaard foutmelding te gebruiken.';
     }
   }
 }

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -1,5 +1,6 @@
 import SimpleInputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/simple-value-input-field';
 import { action } from '@ember/object';
+import { service } from '@ember/service';
 import { guidFor } from '@ember/object/internals';
 import { tracked } from '@glimmer/tracking';
 import { SHACL, RDF } from '@lblod/submission-form-helpers';
@@ -11,6 +12,7 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
 
   @tracked value;
   @tracked useDefaultMessage = false;
+  @service features;
 
   constructor() {
     super(...arguments);

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -23,7 +23,6 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
       undefined,
       this.storeOptions.sourceGraph
     );
-    
     if (newErrorMessage.length > 0) {
       this.value = newErrorMessage;
 
@@ -37,8 +36,8 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
         undefined,
         this.storeOptions.sourceGraph
       );
-      if (errorMessageInForm){
-      this.value = errorMessageInForm;
+      if (errorMessageInForm) {
+        this.value = errorMessageInForm;
       }
     }
 

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -16,7 +16,7 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
 
   constructor() {
     super(...arguments);
-    this.checkForDefaultMessages();
+    this.checkForDefaultMessage();
   }
 
   @action
@@ -96,13 +96,15 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
     }
   }
 
-  checkForDefaultMessages() {
-    const defaultMessages = this.storeOptions.store.match(
-      undefined,
-      SHACL('resultMessage'),
-      undefined,
-      this.storeOptions.metaGraph
-    ).map(item => item.object.value);
+  checkForDefaultMessage() {
+    const defaultMessages = this.storeOptions.store
+      .match(
+        undefined,
+        SHACL('resultMessage'),
+        undefined,
+        this.storeOptions.metaGraph
+      )
+      .map((item) => item.object.value);
     if (defaultMessages.includes(this.value)) {
       this.useDefaultMessage = true;
     }

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -1,0 +1,15 @@
+import InputFieldComponent from '@lblod/ember-submission-form-fields/components/rdf-input-fields/input-field';
+import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
+import { tracked } from '@glimmer/tracking';
+
+export default class ErrorMessageInputFieldComponent extends InputFieldComponent {
+  inputId = 'select-' + guidFor(this);
+
+  @tracked value = 25;
+  
+  @action
+  updateValue() {
+
+  }
+}

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -12,48 +12,44 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
 
   constructor() {
     super(...arguments);
-    this.loadValue();
-  }
-
-  loadValue() {
-    const defaultMessage = this.args.formStore.any(
-      this.storeOptions.sourceNode,
-      SHACL('resultMessage'),
-      undefined,
-      this.storeOptions.sourceGraph
-    );
-    if (defaultMessage) {
-      this.value = defaultMessage;
-    }
   }
 
   @action
   updateValue(e) {
-    this.loadValue();
-
-    this.value = e.target.value.trim();
-
-    const oldValue = this.args.formStore.match(
+    let newErrorMessage = e.target.value.trim();
+    const oldErrorMessage = this.args.formStore.match(
       this.storeOptions.sourceNode,
       SHACL('resultMessage'),
       undefined,
       this.storeOptions.sourceGraph
     );
+    
+    if (newErrorMessage.length > 0) {
+      this.value = newErrorMessage;
 
-    if (this.value.length > 0) {
-      this.args.formStore.removeStatements(oldValue);
-      super.updateValidations();
+      if (oldErrorMessage) {
+        this.args.formStore.removeStatements(oldErrorMessage);
+      }
+    } else {
+      const errorMessageInForm = this.args.formStore.any(
+        this.storeOptions.sourceNode,
+        SHACL('resultMessage'),
+        undefined,
+        this.storeOptions.sourceGraph
+      );
+      if (errorMessageInForm){
+      this.value = errorMessageInForm;
+      }
     }
 
     if (this.value) {
-      const statement = new Statement(
+      const messageToForm = new Statement(
         this.storeOptions.sourceNode,
         SHACL('resultMessage'),
         this.value,
         this.storeOptions.sourceGraph
       );
-      this.args.formStore.addAll([statement]);
-      super.updateValue(this.value);
+      this.args.formStore.addAll([messageToForm]);
     }
   }
 }

--- a/app/components/rdf-form-fields/error-message-input-field.js
+++ b/app/components/rdf-form-fields/error-message-input-field.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import { SHACL } from '@lblod/submission-form-helpers';
 import { Statement } from 'rdflib';
 
-
 export default class ErrorMessageInputFieldComponent extends SimpleInputFieldComponent {
   inputId = 'select-' + guidFor(this);
 
@@ -17,17 +16,17 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
   }
 
   loadValue() {
-    const test = this.args.formStore.any(
+    const defaultMessage = this.args.formStore.any(
       this.storeOptions.sourceNode,
       SHACL('resultMessage'),
       undefined,
       this.storeOptions.sourceGraph
     );
-    if (test) {
-      this.value = test;
+    if (defaultMessage) {
+      this.value = defaultMessage;
     }
   }
-  
+
   @action
   updateValue(e) {
     this.loadValue();
@@ -41,12 +40,12 @@ export default class ErrorMessageInputFieldComponent extends SimpleInputFieldCom
       this.storeOptions.sourceGraph
     );
 
-    if (this.value.length>0) {
-    this.args.formStore.removeStatements(oldValue);
-    super.updateValidations();
+    if (this.value.length > 0) {
+      this.args.formStore.removeStatements(oldValue);
+      super.updateValidations();
     }
 
-    if(this.value) {
+    if (this.value) {
       const statement = new Statement(
         this.storeOptions.sourceNode,
         SHACL('resultMessage'),

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -236,7 +236,13 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
       graph
     );
     if (currentMessage) {
-      return;
+      const currentMessages = this.args.formStore.match(
+        this.storeOptions.sourceNode,
+        SHACL('resultMessage'),
+        undefined,
+        this.storeOptions.sourceGraph
+      );
+      this.args.formStore.removeStatements(currentMessages);
     }
 
     return getDefaultErrorMessageForValidation(

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -16,7 +16,6 @@ import {
 } from '../../utils/forking-store-helpers';
 import { showErrorToasterMessage } from '../../utils/toaster-message-helper';
 import { getGroupingTypeForValidation } from '../../utils/validation/get-grouping-type-for-validation';
-import { getDefaultErrorMessageForValidation } from '../../utils/validation/get-default-error-message-for-validation';
 import { sortObjectsOnProperty } from '../../utils/sort-object-on-property';
 
 export default class ValidationConceptSchemeSelectorComponent extends InputFieldComponent {
@@ -157,12 +156,6 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
       this.storeOptions.sourceGraph
     );
 
-    const defaultErrorMessage = this.findDefaultErrorMessage(
-      this.storeOptions.sourceNode,
-      this.storeOptions.store,
-      this.storeOptions.sourceGraph
-    );
-
     if (validationTypeOption) {
       const groupingType = getGroupingTypeForValidation(
         this.selectedValidationType.subject,
@@ -184,22 +177,11 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
           groupingType,
           this.storeOptions.sourceGraph
         );
-      const defaultErrorMessageStatement =
-        this.createStatementForDefaultErrorMessage(
-          this.storeOptions.sourceNode,
-          defaultErrorMessage,
-          this.storeOptions.sourceGraph
-        );
 
       const StatementsToAdd = [
         validationPathStatement,
         ...rdfTypeAndGroupingStatements,
       ];
-      if (this.features.get('USE_DEFAULT_ERROR_MESSAGE')) {
-        if (defaultErrorMessageStatement) {
-          StatementsToAdd.push(defaultErrorMessageStatement);
-        }
-      }
       this.storeOptions.store.addAll(StatementsToAdd);
     }
 
@@ -228,30 +210,6 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
     }
   }
 
-  findDefaultErrorMessage(sourceNode, store, graph) {
-    const currentMessage = store.any(
-      sourceNode,
-      SHACL('resultMessage'),
-      undefined,
-      graph
-    );
-    if (currentMessage) {
-      const currentMessages = this.args.formStore.match(
-        this.storeOptions.sourceNode,
-        SHACL('resultMessage'),
-        undefined,
-        this.storeOptions.sourceGraph
-      );
-      this.args.formStore.removeStatements(currentMessages);
-    }
-
-    return getDefaultErrorMessageForValidation(
-      this.selectedValidationType.subject,
-      this.storeOptions.store,
-      this.storeOptions.metaGraph
-    );
-  }
-
   createStatementForRdfTypeAndGrouping(
     sourceNode,
     rdfType,
@@ -262,21 +220,6 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
       new Statement(sourceNode, RDF('type'), rdfType, graph),
       new Statement(sourceNode, FORM('grouping'), groupingType, graph),
     ];
-  }
-
-  createStatementForDefaultErrorMessage(
-    sourceNode,
-    defaultErrorMessage,
-    graph
-  ) {
-    if (defaultErrorMessage) {
-      return new Statement(
-        sourceNode,
-        SHACL('resultMessage'),
-        defaultErrorMessage,
-        graph
-      );
-    }
   }
 
   getStatementToAddFieldPathToValidationPath(validationSubject, store, graph) {

--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.js
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.js
@@ -27,7 +27,6 @@ export default class ValidationConceptSchemeSelectorComponent extends InputField
 
   @service toaster;
   @service intl;
-  @service features;
 
   fieldSubject;
 

--- a/app/routes/formbuilder/edit.js
+++ b/app/routes/formbuilder/edit.js
@@ -8,6 +8,7 @@ import ValidationConceptSchemeSelectorComponent from '../../components/rdf-form-
 import { getLocalFileContentAsText } from '../../utils/get-local-file-content';
 import CountryCodeConceptSchemeSelectorComponent from '../../components/rdf-form-fields/country-code-concept-scheme-selector';
 import { GRAPHS } from '../../controllers/formbuilder/edit';
+import ErrorMessageInputFieldComponent from '../../components/rdf-form-fields/error-message-input-field';
 
 export default class FormbuilderEditRoute extends Route {
   @service store;
@@ -95,6 +96,11 @@ export default class FormbuilderEditRoute extends Route {
         displayType:
           'http://lblod.data.gift/display-types/countryCodeConceptSchemeSelector',
         edit: CountryCodeConceptSchemeSelectorComponent,
+      },
+      {
+        displayType:
+          'http://lblod.data.gift/display-types/errorMessageInputField',
+        edit: ErrorMessageInputFieldComponent,
       },
     ]);
   }

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,7 +19,7 @@ module.exports = function (environment) {
       // when it is created
     },
     featureFlags: {
-      USE_DEFAULT_ERROR_MESSAGE: false, // when switching uncomment help text error message public/forms/validation/form.ttl
+      USE_DEFAULT_ERROR_MESSAGE: true, // when switching uncomment help text error message public/forms/validation/form.ttl
       CAN_CREATE_OWN_CODELIST: false, // when switching to true also uncomment the `codelijsten/new` route in `router.js`
     },
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16162,16 +16162,6 @@
       "integrity": "sha512-yzkH0uog6Vv/vQ9+rhSKxecnqGUZHYncg7qS7voz3Q76+TAi1SGiOKk2mlOvusQnFz9Dc4BC/NMkeXu11YgjJg==",
       "dev": true
     },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -40330,13 +40320,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/filesize": {
       "version": "10.0.12",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.12.tgz",
@@ -40970,20 +40953,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -45045,13 +45014,6 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
-    },
-    "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -54704,25 +54666,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/watchpack-chokidar2/node_modules/fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-      "deprecated": "The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      },
-      "engines": {
-        "node": ">= 4.0"
       }
     },
     "node_modules/watchpack-chokidar2/node_modules/glob-parent": {

--- a/public/forms/validation/form.ttl
+++ b/public/forms/validation/form.ttl
@@ -163,12 +163,12 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
     ext:validationResultMessageF a form:Field ;
       sh:name "Foutmelding" ;
       sh:order 100 ; # I think we always want to show this below the conditional fields?
-      # comment when USE_DEFAULT_ERROE_MESSAGE is false
-      # form:help """
-      #   Klik hier om het standaardbericht te tonen of aan te passen.
-      # """ ;
+      # comment when USE_DEFAULT_ERROR_MESSAGE is false
+      form:help """
+        Klik hier om het standaardbericht te tonen of aan te passen.
+      """ ;
       sh:path sh:resultMessage ;
-      form:displayType displayTypes:defaultInput ;
+      form:displayType displayTypes:errorMessageInputField ;
       form:partOf ext:formFieldS .
 
     ##########################################################

--- a/public/forms/validation/form.ttl
+++ b/public/forms/validation/form.ttl
@@ -164,6 +164,9 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
       sh:name "Foutmelding" ;
       sh:order 100 ; # I think we always want to show this below the conditional fields?
       # comment when USE_DEFAULT_ERROR_MESSAGE is false
+      form:help """
+        Wanneer je van validatie type veranderd, toggle dan foutmelding aan en uit om de standaard foutmedling te updaten.
+      """ ; 
       sh:path sh:resultMessage ;
       form:displayType displayTypes:errorMessageInputField ;
       form:partOf ext:formFieldS .

--- a/public/forms/validation/form.ttl
+++ b/public/forms/validation/form.ttl
@@ -164,9 +164,6 @@ fields:phoneNumberCountryCodeCFG a form:ConditionalFieldGroup ;
       sh:name "Foutmelding" ;
       sh:order 100 ; # I think we always want to show this below the conditional fields?
       # comment when USE_DEFAULT_ERROR_MESSAGE is false
-      form:help """
-        Klik hier om het standaardbericht te tonen of aan te passen.
-      """ ;
       sh:path sh:resultMessage ;
       form:displayType displayTypes:errorMessageInputField ;
       form:partOf ext:formFieldS .


### PR DESCRIPTION
## ID
 SFB-122

 ## Description

It is possible to add multiple error messages to a validation, this shouldn't be possible. Fixed the double error messages by making a custom rdf form field. This input field will remove the previous error message when making a new one.

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test
1) choose a validation type
2) Click in the input field, the default error message will show (if there is one of course) or type a custom one
3) try changing validation type
4) if you want the default error message of that validation type remove the old one and just click out of the input field or again type custom one

 ## Links to other PR's
