### PR TITLE
SFB-151: bug fix unsaved changes modal on delete

### DIFF
--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -45,6 +45,7 @@ export default class ToolbarComponent extends Component {
     const generatedForm = this.args.model;
     const isDeleted = await generatedForm.destroyRecord();
     if (isDeleted) {
+      this.formCodeManager.reset();
       this.router.transitionTo('index');
     }
   }

--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -46,6 +46,15 @@ export default class ToolbarComponent extends Component {
     const isDeleted = await generatedForm.destroyRecord();
     if (isDeleted) {
       this.formCodeManager.reset();
+      this.toaster.success(
+        this.intl.t('messages.success.formDeleted', {
+          name: this.formLabel,
+        }),
+        this.intl.t('messages.subjects.deleted'),
+        {
+          timeOut: 5000,
+        }
+      );
       this.router.transitionTo('index');
     }
   }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -31,7 +31,7 @@ export default class IndexController extends Controller {
         this.intl.t('messages.success.formDeleted', {
           name: this.formToDelete.label,
         }),
-        this.intl.t('messages.subjects.success'),
+        this.intl.t('messages.subjects.deleted'),
         {
           timeOut: 5000,
         }

--- a/app/routes/formbuilder/edit.js
+++ b/app/routes/formbuilder/edit.js
@@ -46,6 +46,10 @@ export default class FormbuilderEditRoute extends Route {
 
   @action
   willTransition(transition) {
+    if (!this.formCodeManager.isFormIdSet()) {
+      return;
+    }
+
     const nextRoute = transition.targetName;
 
     if (transition.to.parent.name == 'formbuilder.edit') {

--- a/app/services/form-code-manager.js
+++ b/app/services/form-code-manager.js
@@ -54,6 +54,11 @@ export default class FormCodeManagerService extends Service {
     this.latestVersion = this.startVersion;
   }
 
+  reset() {
+    this.clearHistory();
+    this.formId = null;
+  }
+
   #getTtlOfVersion(version) {
     if (version <= this.startVersion) {
       throw this.intl.t('messages.feedback.lowestVersionAvailable');
@@ -78,5 +83,9 @@ export default class FormCodeManagerService extends Service {
   setFormId(generatedFormId) {
     // Should we check if the ID exists?
     this.formId = generatedFormId;
+  }
+
+  isFormIdSet() {
+    return this.formId;
   }
 }

--- a/translations/messages/en-us.yaml
+++ b/translations/messages/en-us.yaml
@@ -3,6 +3,7 @@ messages:
     success: "Success"
     error: "Error"
     characters: "Characters"
+    deleted: "Verwijderd"
   error:
     couldNotFetchFormWithId: "Could not find form with id: {id}"
     somethingWentWrong: "Oops, something went wrong"

--- a/translations/messages/nl-be.yaml
+++ b/translations/messages/nl-be.yaml
@@ -3,6 +3,7 @@ messages:
     success: "Success"
     error: "Error"
     characters: "Karakters"
+    deleted: "Verwijderd"
   error:
     couldNotFetchFormWithId: "Kon formulier met id: {id} niet vinden"
     somethingWentWrong: "Oeps, er is iets mis gegaan"


### PR DESCRIPTION
## ID
 [SFB-151](https://binnenland.atlassian.net/browse/SFB-151)

 ## Description

When updating the form and than deleting it without saving the a modal is shown after that you confirmed to delete the form. This modal should not be shown when the form is already delete.

 ## Type of change

 - [x ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Create a form and change something in the ttl code
2. Go to the split button and delete the form
3. Cancel the deletion => the form should be in the same state as before and you did not see any modal for unsaved changes
4. Press the delete button again and confirm that you want to delete it. The unsaved changes modal is not shown and a toaster is provided that the form is successfully deleted

 ## Links to other PR's

- /