### PR TITLE
SFB-125: check version of ttl code

### DIFF
--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -25,6 +25,7 @@ export default class FormbuilderEditController extends Controller {
   @service toaster;
   @service intl;
   @service('form-code-manager') formCodeManager;
+  @service('form-version') formVersionManager;
 
   @tracked formCode;
 
@@ -48,6 +49,10 @@ export default class FormbuilderEditController extends Controller {
     if (newCode) {
       this.formCode = newCode;
       this.formCodeManager.addFormCode(this.formCode);
+      console.info(
+        `Current version of form:`,
+        this.formVersionManager.getVersionForTtl(this.formCode)
+      );
     }
     this.setFormChanged(this.formCodeManager.isLatestDeviatingFromReference());
     this.setupPreviewForm.perform(this.formCodeManager.getTtlOfLatestVersion());

--- a/app/services/form-version.js
+++ b/app/services/form-version.js
@@ -1,0 +1,49 @@
+import Service from '@ember/service';
+
+export default class FormVersionService extends Service {
+  VERSION_ONE = 'V1';
+  VERSION_TWO = 'V2';
+  VERSION_UNDETERMINED = 'UNKNOWN';
+
+  PREFERED_VERSION = this.VERSION_TWO;
+
+  getVersionForTtl(ttlCode) {
+    if (this.isCombinationOfOneAndTwo(ttlCode)) {
+      return this.VERSION_UNDETERMINED;
+    }
+
+    if (this.isVersionTwoForm(ttlCode)) {
+      return this.VERSION_TWO;
+    }
+
+    if (this.isVersionOneForm(ttlCode)) {
+      return this.VERSION_ONE;
+    }
+
+    return this.VERSION_UNDETERMINED;
+  }
+
+  isVersionOneForm(ttlCode) {
+    const predicates = [':group', ':PropertyGroup', ':validations'];
+
+    return predicates.some((predicate) =>
+      ttlCode.match(this.#createRegexForWord(predicate))
+    );
+  }
+
+  isVersionTwoForm(ttlCode) {
+    const predicates = [':partOf', ':Section', ':validatedBy'];
+
+    return predicates.some((predicate) =>
+      ttlCode.match(this.#createRegexForWord(predicate))
+    );
+  }
+
+  isCombinationOfOneAndTwo(ttlCode) {
+    return this.isVersionOneForm(ttlCode) && this.isVersionTwoForm(ttlCode);
+  }
+
+  #createRegexForWord(word) {
+    return new RegExp('\\b' + word + '\\b', 'g');
+  }
+}

--- a/tests/unit/services/form-version-test.js
+++ b/tests/unit/services/form-version-test.js
@@ -1,0 +1,68 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-form-builder/tests/helpers';
+import versionOneForm from './resources/version-one-form';
+import versionTwoForm from './resources/version-two-form';
+import versionOneAndTwoCombinationForm from './resources/version-one-and-two-combination-form';
+
+module('Unit | Service | form-version', function (hooks) {
+  setupTest(hooks);
+
+  test('Service is found', function (assert) {
+    let service = this.owner.lookup('service:form-version');
+    assert.ok(service);
+  });
+
+  test('Versions are defined correctly', function (assert) {
+    let service = this.owner.lookup('service:form-version');
+
+    assert.deepEqual(service.VERSION_ONE, 'V1');
+    assert.deepEqual(service.VERSION_TWO, 'V2');
+    assert.deepEqual(service.VERSION_UNDETERMINED, 'UNKNOWN');
+  });
+
+  test('Can detect a V1 form', function (assert) {
+    let service = this.owner.lookup('service:form-version');
+    const vOneForm = versionOneForm;
+
+    assert.true(service.isVersionOneForm(vOneForm));
+    assert.false(service.isVersionTwoForm(vOneForm));
+    assert.deepEqual(service.getVersionForTtl(vOneForm), service.VERSION_ONE);
+  });
+
+  test('Can detect a V2 form', function (assert) {
+    let service = this.owner.lookup('service:form-version');
+    const vTwoForm = versionTwoForm;
+
+    assert.true(service.isVersionTwoForm(vTwoForm));
+    assert.false(service.isVersionOneForm(vTwoForm));
+    assert.deepEqual(service.getVersionForTtl(vTwoForm), service.VERSION_TWO);
+  });
+
+  test('Combination of V1 & 2V forms is version undertermined', function (assert) {
+    let service = this.owner.lookup('service:form-version');
+    const combinationOfVersionOneAndTwo = versionOneAndTwoCombinationForm;
+
+    assert.true(
+      service.isCombinationOfOneAndTwo(combinationOfVersionOneAndTwo)
+    );
+    assert.true(service.isVersionTwoForm(combinationOfVersionOneAndTwo));
+    assert.true(service.isVersionOneForm(combinationOfVersionOneAndTwo));
+    assert.deepEqual(
+      service.getVersionForTtl(combinationOfVersionOneAndTwo),
+      service.VERSION_UNDETERMINED
+    );
+  });
+
+  test('If version cannot be determined it returns unknown', function (assert) {
+    let service = this.owner.lookup('service:form-version');
+    const underterminedTtlCode = ``;
+
+    assert.false(service.isCombinationOfOneAndTwo(underterminedTtlCode));
+    assert.false(service.isVersionTwoForm(underterminedTtlCode));
+    assert.false(service.isVersionOneForm(underterminedTtlCode));
+    assert.deepEqual(
+      service.getVersionForTtl(underterminedTtlCode),
+      service.VERSION_UNDETERMINED
+    );
+  });
+});

--- a/tests/unit/services/resources/version-one-and-two-combination-form.js
+++ b/tests/unit/services/resources/version-one-and-two-combination-form.js
@@ -1,0 +1,34 @@
+export default `
+@prefix : <#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix nodes: <http://data.lblod.info/form-data/nodes/>.
+@prefix emb: <http://ember-submission-form-fields/>.
+
+nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+    a form:Field;
+    form:displayType displayTypes:conceptSchemeSelector;
+    form:options
+        """{
+  "conceptScheme": "http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode"
+}""";
+    form:partOf nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
+    form:validations
+            [
+                a form:RequiredConstraint;
+                form:grouping form:Bag;
+                sh:order 1;
+                sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+                sh:resultMessage "Dit veld is verplicht"
+            ];
+    sh:name "Veldnaam";
+    sh:order 2;
+    sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
+nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1
+a form:PropertyGroup; sh:name "Titel"; sh:order 1 .
+emb:source-node
+    a form:Form, form:TopLevelForm;
+    form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
+    form:partOf nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
+`;

--- a/tests/unit/services/resources/version-one-form.js
+++ b/tests/unit/services/resources/version-one-form.js
@@ -1,0 +1,34 @@
+export default `
+@prefix : <#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix nodes: <http://data.lblod.info/form-data/nodes/>.
+@prefix emb: <http://ember-submission-form-fields/>.
+
+nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+    a form:Field;
+    form:displayType displayTypes:conceptSchemeSelector;
+    form:options
+        """{
+  "conceptScheme": "http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode"
+}""";
+    form:validations
+            [
+                a form:RequiredConstraint;
+                form:grouping form:Bag;
+                sh:order 1;
+                sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+                sh:resultMessage "Dit veld is verplicht"
+            ];
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
+    sh:name "Veldnaam";
+    sh:order 2;
+    sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
+nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1
+a form:PropertyGroup; sh:name "Titel"; sh:order 1 .
+emb:source-node
+    a form:Form, form:TopLevelForm;
+    form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
+    sh:group nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
+`;

--- a/tests/unit/services/resources/version-two-form.js
+++ b/tests/unit/services/resources/version-two-form.js
@@ -1,0 +1,34 @@
+export default `
+@prefix : <#>.
+@prefix form: <http://lblod.data.gift/vocabularies/forms/>.
+@prefix sh: <http://www.w3.org/ns/shacl#>.
+@prefix displayTypes: <http://lblod.data.gift/display-types/>.
+@prefix nodes: <http://data.lblod.info/form-data/nodes/>.
+@prefix emb: <http://ember-submission-form-fields/>.
+
+nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+    a form:Field;
+    form:displayType displayTypes:conceptSchemeSelector;
+    form:options
+        """{
+  "conceptScheme": "http://data.vlaanderen.be/id/conceptscheme/BeleidsdomeinCode"
+}""";
+    form:partOf nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1;
+    form:validatedBy
+            [
+                a form:RequiredConstraint;
+                form:grouping form:Bag;
+                sh:order 1;
+                sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+                sh:resultMessage "Dit veld is verplicht"
+            ];
+    sh:name "Veldnaam";
+    sh:order 2;
+    sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40 .
+nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1
+a form:Section; sh:name "Titel"; sh:order 1 .
+emb:source-node
+    a form:Form, form:TopLevelForm;
+    form:includes nodes:24289e48-258f-4919-8c3e-5783a6acb4a4;
+    form:partOf nodes:d7b33768-3723-4291-a7be-3d8a7d7cdbc1 .
+`;


### PR DESCRIPTION
## ID
 [SFB-125](https://binnenland.atlassian.net/browse/SFB-125)

 ## Description

Before we can show a message that the user is editing a V1 form the check of the version needs to happen first. 

I did not make use of the violations of the shacl shape validation as the way it is implemented now feels easier to maintain, understand and use in the code.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. all test should be green
2. a console log with the version should be visible
3. depending on what version of form you are using it should display the correct one

 ## Links to other PR's

 - https://github.com/lblod/frontend-form-builder/pull/115