### PR TITLE
SFB-125: extend show message on v1 form

### DIFF
--- a/app/controllers/formbuilder/edit.js
+++ b/app/controllers/formbuilder/edit.js
@@ -28,6 +28,7 @@ export default class FormbuilderEditController extends Controller {
   @service('form-version') formVersionManager;
 
   @tracked formCode;
+  @tracked formVersion;
 
   @tracked formChanged;
 
@@ -49,10 +50,10 @@ export default class FormbuilderEditController extends Controller {
     if (newCode) {
       this.formCode = newCode;
       this.formCodeManager.addFormCode(this.formCode);
-      console.info(
-        `Current version of form:`,
-        this.formVersionManager.getVersionForTtl(this.formCode)
+      this.formVersion = this.formVersionManager.getVersionForTtl(
+        this.formCode
       );
+      console.info(`Current version of form:`, this.formVersion);
     }
     this.setFormChanged(this.formCodeManager.isLatestDeviatingFromReference());
     this.setupPreviewForm.perform(this.formCodeManager.getTtlOfLatestVersion());

--- a/app/helpers/is-equal.js
+++ b/app/helpers/is-equal.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function isEqual([current, comparison]) {
+  return current == comparison;
+});

--- a/app/templates/formbuilder/edit.hbs
+++ b/app/templates/formbuilder/edit.hbs
@@ -7,6 +7,20 @@
   @onCodeChange={{this.handleCodeChange}}
   @setFormChanged={{this.setFormChanged}}
 />
+{{#if (is-equal this.formVersion this.formVersionManager.VERSION_ONE)}}
+  <AuAlert
+    @title=""
+    @skin="warning"
+    @icon="alert-triangle"
+    @size="small"
+    @closable={{false}}
+  >
+    <p>{{t
+        "messages.feedback.warnV1Form"
+        version=this.formVersionManager.VERSION_ONE
+      }}</p>
+  </AuAlert>
+{{/if}}
 
 <AuTabs
   class="au-u-padding-left-small au-u-padding-right-small"
@@ -60,10 +74,10 @@
   </div>
 </AuBodyContainer>
 
-<AuModal 
-    @modalOpen={{this.isSaveModalOpen}} 
-    @closeModal={{fn (mut this.isSaveModalOpen) false}}
-  >
+<AuModal
+  @modalOpen={{this.isSaveModalOpen}}
+  @closeModal={{fn (mut this.isSaveModalOpen) false}}
+>
   <:title>{{t "confirmation.saveUnsavedChangesTitle"}}</:title>
   <:body>
     {{t "confirmation.saveUnsavedChangesQuestion"}}
@@ -84,7 +98,7 @@
       >
         {{t "confirmation.saveChanges"}}
       </AuButton>
-      
+
     </AuButtonGroup>
   </:footer>
 </AuModal>

--- a/translations/messages/en-us.yaml
+++ b/translations/messages/en-us.yaml
@@ -25,6 +25,7 @@ messages:
     onlyFieldsAllowedToDisplayUnderSections: "Only fields are supported to be displayed per section"
     lowestVersionAvailable: "De laagste beschikbare versie: 0"
     highestversionAvailable: "De laatste versie is v{version}"
+    warnV1Form: "We noticed that you are editing a {version} form. Functionality will be limited."
   loading:
     creatingNewUserTest: "Creating new user test"
     loadingOverview: "Loading Overview"

--- a/translations/messages/nl-be.yaml
+++ b/translations/messages/nl-be.yaml
@@ -25,6 +25,7 @@ messages:
     onlyFieldsAllowedToDisplayUnderSections: "Velden zijn enkel toeglaten om te tonen onder de sectie"
     lowestVersionAvailable: "The lowest version available is version: 0"
     highestversionAvailable: "The highest version available is v{version}"
+    warnV1Form: "We hebben gemerkt dat je een {version} formulier aan het editeren bent. Sommige functies zullen gelimiteerd zijn."
   loading:
     creatingNewUserTest: "Nieuwe gebruikerstest aan het maken"
     loadingOverview: "Overzicht aan het laden"


### PR DESCRIPTION
## ID
 [SFB-125](https://binnenland.atlassian.net/browse/SFB-125)

 ## Description

Showing an alert when the version of the form is a V1 form. Added a translation for this so it can easely be changed if we want. This banner will be shown above the navigation tabs in the edit route.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Open a V1 form => alert shows
2. Open a V2 form => no alert
3. Edit a V1 or V2 form => the alert will only show when you have a full V1 or V2 form not a combination

 ## Links to other PR's

 - https://github.com/lblod/frontend-form-builder/pull/114