### PR TITLE
SFB-156: export custom codelist

### DIFF
--- a/app/components/toolbar.js
+++ b/app/components/toolbar.js
@@ -6,6 +6,7 @@ import {
   DESCRIPTION_NOT_USED_PLACEHOLDER,
   NAME_INPUT_CHAR_LIMIT,
 } from '../utils/constants';
+import { downloadTextAsFile } from '../utils/download-text-as-file';
 
 export default class ToolbarComponent extends Component {
   @service store;
@@ -21,17 +22,14 @@ export default class ToolbarComponent extends Component {
 
   @action
   saveLocally() {
-    // Create a link
-    let downloadLink = document.createElement('a');
-    downloadLink.download = this.formLabel;
-
-    // generate Blob where file content will exists
-    let blob = new Blob([this.args.code], { type: 'text/plain' });
-    downloadLink.href = window.URL.createObjectURL(blob);
-
-    // Click file to download then destroy link
-    downloadLink.click();
-    downloadLink.remove();
+    downloadTextAsFile(
+      {
+        filename: this.formLabel,
+        contentAsText: this.args.code,
+      },
+      document,
+      window
+    );
     this.isEditingName = false;
   }
 

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -18,6 +18,7 @@ import { updateConcept } from '../../utils/codelijsten/update-concept';
 import { isConceptArrayChanged } from '../../utils/codelijsten/compare-concept-arrays';
 import { restartableTask } from 'ember-concurrency';
 import { sortObjectsOnProperty } from '../../utils/sort-object-on-property';
+import { downloadTextAsFile } from '../../utils/download-text-as-file';
 
 export default class CodelijstenEditController extends Controller {
   @service toaster;
@@ -291,8 +292,25 @@ export default class CodelijstenEditController extends Controller {
     );
     const codelistTtlCode =
       await latestConceptScheme.modelWithConceptsAsTtlCode();
-    console.log('latestConceptScheme:', latestConceptScheme);
-    console.log('ttl', codelistTtlCode);
+
+    downloadTextAsFile(
+      {
+        filename: this.getExportFileName(),
+        contentAsText: codelistTtlCode,
+      },
+      document,
+      window
+    );
+  }
+
+  getExportFileName() {
+    return `codelijst-${this.conceptScheme.id}-${this.getIsoDate()}.ttl`;
+  }
+
+  getIsoDate() {
+    const isoDate = new Date().toISOString();
+
+    return isoDate.slice(0, 10);
   }
 
   isConceptListIncludingEmptyValues() {

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -285,8 +285,14 @@ export default class CodelijstenEditController extends Controller {
   }
 
   @action
-  exportCodelist() {
-    console.log(`export codelist`);
+  async exportCodelist() {
+    const latestConceptScheme = await this.getConceptSchemeById(
+      this.conceptScheme.id
+    );
+    const codelistTtlCode =
+      await latestConceptScheme.modelWithConceptsAsTtlCode();
+    console.log('latestConceptScheme:', latestConceptScheme);
+    console.log('ttl', codelistTtlCode);
   }
 
   isConceptListIncludingEmptyValues() {

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -284,6 +284,11 @@ export default class CodelijstenEditController extends Controller {
     }
   }
 
+  @action
+  exportCodelist() {
+    console.log(`export codelist`);
+  }
+
   isConceptListIncludingEmptyValues() {
     return this.concepts.every((concept) => concept.label.trim() !== '');
   }

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -49,6 +49,17 @@
         >
           <AuButton
             @skin="link"
+            @icon="export"
+            @iconAlignment="left"
+            role="menuitem"
+            @disabled={{this.isPrivateConceptScheme}}
+            @loadingMessage={{t "messages.loading.isDeleting"}}
+            {{on "click" this.exportCodelist}}
+          >
+            {{t "actions.exportCodelist"}}
+          </AuButton>
+          <AuButton
+            @skin="link"
             @icon="bin"
             @iconAlignment="left"
             @alert={{true}}

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -53,7 +53,7 @@
             @iconAlignment="left"
             role="menuitem"
             @disabled={{this.isPrivateConceptScheme}}
-            @loadingMessage={{t "messages.loading.isDeleting"}}
+            @loadingMessage={{t "messages.loading.downloading"}}
             {{on "click" this.exportCodelist}}
           >
             {{t "actions.exportCodelist"}}

--- a/app/utils/download-text-as-file.js
+++ b/app/utils/download-text-as-file.js
@@ -1,0 +1,17 @@
+export function downloadTextAsFile(
+  { filename, contentAsText },
+  document,
+  window
+) {
+  // Create a link
+  let downloadLink = document.createElement('a');
+  downloadLink.download = filename;
+
+  // generate Blob where file content will exists
+  let blob = new Blob([contentAsText], { type: 'text/plain' });
+  downloadLink.href = window.URL.createObjectURL(blob);
+
+  // Click file to download then destroy link
+  downloadLink.click();
+  downloadLink.remove();
+}

--- a/translations/codelists/en-us.yaml
+++ b/translations/codelists/en-us.yaml
@@ -31,3 +31,6 @@ messages:
   success:
     conceptsUpdated: "Updated concepts"
     codelistUpdated: "Updated codelist"
+
+actions:
+  exportCodelist: "Export"

--- a/translations/codelists/en-us.yaml
+++ b/translations/codelists/en-us.yaml
@@ -31,6 +31,8 @@ messages:
   success:
     conceptsUpdated: "Updated concepts"
     codelistUpdated: "Updated codelist"
+  loading:
+    downloading: "Downloading"
 
 actions:
   exportCodelist: "Export"

--- a/translations/codelists/nl-be.yaml
+++ b/translations/codelists/nl-be.yaml
@@ -31,6 +31,8 @@ messages:
   success:
     conceptsUpdated: "Concepten bijgewerkt"
     codelistUpdated: "Codelijst bijgewerkt"
+  loading:
+    downloading: "Downloaden"
 
 actions:
   exportCodelist: "Exporteer"

--- a/translations/codelists/nl-be.yaml
+++ b/translations/codelists/nl-be.yaml
@@ -31,3 +31,6 @@ messages:
   success:
     conceptsUpdated: "Concepten bijgewerkt"
     codelistUpdated: "Codelijst bijgewerkt"
+
+actions:
+  exportCodelist: "Exporteer"


### PR DESCRIPTION
## ID
 [SFB-156](https://binnenland.atlassian.net/browse/SFB-156)

 ## Description

When users make their own codelists they can only see this list in the codelist details page or in the preview form when creating a form. Of course they also want the information from the codelist in their application. We add an extra option to the split button in the detail view so users can export the code code as a ttl file.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. create/go to a custom codelist
2. Press the split button and donwload the file.
3. When opening the file the content of the codelist should be in there
4. As the toolbar also uses the same new download method try and export the ttl code of a form 

 ## Links to other PR's

 - /
 
## Attachments
![image](https://github.com/lblod/frontend-form-builder/assets/36266973/c8ace715-ebc8-4c17-9e3f-df51c0951659)
