### PR TITLE
SFB-168:  Archive custom codelists

### DIFF
--- a/app/components/concept-scheme-uri-selector.js
+++ b/app/components/concept-scheme-uri-selector.js
@@ -56,7 +56,11 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
       },
     });
 
-    this.options = sortObjectsOnProperty([...conceptSchemes], 'label');
+    const notArchivedConceptSchemes = [...conceptSchemes].filter(
+      (scheme) => !scheme.isArchived
+    );
+
+    this.options = sortObjectsOnProperty(notArchivedConceptSchemes, 'label');
 
     if (this.args.forField) {
       await this.loadSelected();

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -254,12 +254,25 @@ export default class CodelijstenEditController extends Controller {
   }
 
   archiveCodelist = restartableTask(async () => {
+    this.conceptScheme.isarchived = true;
+
+    try {
+      this.conceptScheme.save();
+      this.conceptScheme.reload();
+      showSuccessToasterMessage(
+        this.toaster,
+        this.codelistName,
+        this.intl.t('messages.subjects.archived')
+      );
+    } catch (error) {
+      showErrorToasterMessage(
+        this.toaster,
+        this.intl.t('messages.error.somethingWentWrong'),
+        this.intl.t('crud.archive')
+      );
+    }
+
     this.isArchiveModalOpen = false;
-    showSuccessToasterMessage(
-      this.toaster,
-      this.codelistName,
-      this.intl.t('messages.subjects.archived')
-    );
     this.router.transitionTo('codelijsten.index');
   });
 

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -38,9 +38,26 @@ export default class CodelijstenEditController extends Controller {
   @tracked isArchiveModalOpen;
   @tracked isDuplicateName;
   @tracked isSaveDisabled;
-  @tracked isPrivateConceptScheme;
 
   conceptsInDatabase;
+
+  get isReadOnly() {
+    if (!this.conceptScheme) return true;
+
+    return this.isPrivateConceptScheme || this.isArchivedConceptScheme;
+  }
+
+  get isPrivateConceptScheme() {
+    if (!this.conceptScheme) return true;
+
+    return !this.conceptScheme.isPublic;
+  }
+
+  get isArchivedConceptScheme() {
+    if (!this.conceptScheme) return false;
+
+    return this.conceptScheme.isArchived;
+  }
 
   setup = restartableTask(async (conceptSchemeId) => {
     this.conceptScheme = await this.getConceptSchemeById(conceptSchemeId);
@@ -53,7 +70,6 @@ export default class CodelijstenEditController extends Controller {
   });
 
   setValuesFromConceptscheme() {
-    this.isPrivateConceptScheme = !this.conceptScheme.isPublic;
     this.codelistName = this.conceptScheme.label;
     this.codelistDescription = this.conceptScheme.description;
   }

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -16,7 +16,7 @@ import { deleteConceptScheme } from '../../utils/codelijsten/delete-concept-sche
 import { isDuplicateConceptSchemeName } from '../../utils/codelijsten/is-duplicate-concept-scheme-name';
 import { updateConcept } from '../../utils/codelijsten/update-concept';
 import { isConceptArrayChanged } from '../../utils/codelijsten/compare-concept-arrays';
-import { restartableTask } from 'ember-concurrency';
+import { restartableTask, timeout } from 'ember-concurrency';
 import { sortObjectsOnProperty } from '../../utils/sort-object-on-property';
 import { downloadTextAsFile } from '../../utils/download-text-as-file';
 
@@ -67,6 +67,8 @@ export default class CodelijstenEditController extends Controller {
     this.setValuesFromConcepts(conceptArray);
 
     this.setIsSaveButtonDisabled();
+    // Prevent flickering between laoding and showing content if small lists are shown
+    await timeout(100);
   });
 
   setValuesFromConceptscheme() {

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -35,7 +35,7 @@ export default class CodelijstenEditController extends Controller {
   @tracked nameErrorMessage;
   @tracked descriptionErrorMessage;
 
-  @tracked isDeleteModalOpen;
+  @tracked isArchiveModalOpen;
   @tracked isDuplicateName;
   @tracked isSaveDisabled;
   @tracked isPrivateConceptScheme;
@@ -247,13 +247,21 @@ export default class CodelijstenEditController extends Controller {
     }
   }
 
-  @action
   async deleteCodelist() {
     await this.deleteConcepts(this.concepts, true);
     await deleteConceptScheme(this.conceptScheme.id, this.store, this.toaster);
-    this.isDeleteModalOpen = false;
     this.router.transitionTo('codelijsten.index');
   }
+
+  archiveCodelist = restartableTask(async () => {
+    this.isArchiveModalOpen = false;
+    showSuccessToasterMessage(
+      this.toaster,
+      this.codelistName,
+      this.intl.t('messages.subjects.archived')
+    );
+    this.router.transitionTo('codelijsten.index');
+  });
 
   setIsSaveButtonDisabled() {
     if (this.conceptScheme.isPublic) {

--- a/app/models/concept-scheme.js
+++ b/app/models/concept-scheme.js
@@ -7,6 +7,7 @@ export default class ConceptSchemeModel extends Model {
   @attr preflabel;
   @attr description;
   @attr ispublic;
+  @attr isarchived;
   @hasMany('concept', { inverse: null, async: true }) concepts;
 
   get label() {
@@ -15,6 +16,10 @@ export default class ConceptSchemeModel extends Model {
 
   get isPublic() {
     return this.ispublic;
+  }
+
+  get isArchived() {
+    return this.isarchived ?? false;
   }
 
   get createdAt() {

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -82,7 +82,7 @@
       </AuAlert>
     {{else}}
       {{#if this.isArchivedConceptScheme}}
-        <AuAlert @title={{"Opgelet"}} @skin={{"warning"}} @icon={{"login"}}>
+        <AuAlert @title={{"Opgelet"}} @skin={{"info"}} @icon={{"archive"}}>
           <p>{{t "codelists.alert.archivedCodelist"}}</p>
         </AuAlert>
       {{/if}}

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -26,7 +26,7 @@
         {{t "crud.save"}}
       </AuButton>
 
-      {{#if this.isPrivateConceptScheme}}
+      {{#if this.isReadOnly}}
         <span id="saveSplitButton_dropdown">
           <AuButton
             @disabled={{true}}
@@ -80,7 +80,14 @@
       <AuAlert @title={{"Opgelet"}} @skin={{"warning"}} @icon={{"login"}}>
         <p>{{t "codelists.alert.genericCodelist"}}</p>
       </AuAlert>
+    {{else}}
+      {{#if this.isArchivedConceptScheme}}
+        <AuAlert @title={{"Opgelet"}} @skin={{"warning"}} @icon={{"login"}}>
+          <p>{{t "codelists.alert.archivedCodelist"}}</p>
+        </AuAlert>
+      {{/if}}
     {{/if}}
+
     <div class="au-u-3-5 au-u-margin-bottom-large">
       <AuLabel for="input-codelist-name" @required={{true}}>
         {{t "codelists.nameOfCodelist"}}
@@ -89,7 +96,7 @@
         id="input-codelist-name"
         @width="block"
         @error={{this.nameErrorMessage}}
-        @disabled={{this.isPrivateConceptScheme}}
+        @disabled={{this.isReadOnly}}
         value={{this.codelistName}}
         {{on "blur" this.handleNameChange}}
       />
@@ -98,7 +105,7 @@
       {{/if}}
     </div>
     <div class="au-u-3-5 au-u-margin-bottom-large">
-      {{#if this.isPrivateConceptScheme}}
+      {{#if this.isReadOnly}}
         <p>{{this.codelistDescription}}</p>
       {{else}}
         <AuLabel for="input-codelist-description" @required={{true}}>
@@ -108,7 +115,7 @@
           id="input-codelist-description"
           @width="block"
           @error={{this.descriptionErrorMessage}}
-          @disabled={{this.isPrivateConceptScheme}}
+          @disabled={{this.isReadOnly}}
           value={{this.codelistDescription}}
           {{on "blur" this.handleDescriptionChange}}
         />
@@ -125,7 +132,7 @@
       <:header>
         <tr>
           <th>{{t "table.columns.label"}}</th>
-          {{#unless this.isPrivateConceptScheme}}
+          {{#unless this.isReadOnly}}
             <th>{{t "table.columns.actions"}}</th>
           {{/unless}}
         </tr>
@@ -134,7 +141,7 @@
         {{#if this.concepts}}
           {{#each this.concepts as |concept|}}
             <tr>
-              {{#if this.isPrivateConceptScheme}}
+              {{#if this.isReadOnly}}
                 <td class="au-u-visible-medium-up">
                   {{concept.label}}</td>
               {{else}}
@@ -145,7 +152,7 @@
                     {{on "blur" (fn this.handleConceptChange concept)}}
                   /></td>
               {{/if}}
-              {{#unless this.isPrivateConceptScheme}}
+              {{#unless this.isReadOnly}}
                 <td class="au-u-visible-medium-up">
                   <AuButton
                     @icon="bin"
@@ -162,7 +169,7 @@
             </tr>
           {{/each}}
         {{/if}}
-        {{#unless this.isPrivateConceptScheme}}
+        {{#unless this.isReadOnly}}
           <tr>
             <td class="au-u-visible-medium-up">
               <AuButton

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -59,16 +59,15 @@
             {{t "actions.exportCodelist"}}
           </AuButton>
           <AuButton
-            @skin="link"
-            @icon="bin"
+            @icon="archive"
             @iconAlignment="left"
             @alert={{true}}
             role="menuitem"
             @disabled={{this.isPrivateConceptScheme}}
-            @loadingMessage={{t "messages.loading.isDeleting"}}
+            @loadingMessage={{t "messages.loading.isArchiving"}}
             {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
           >
-            {{t "crud.delete"}}
+            {{t "crud.archive"}}
           </AuButton>
         </AuDropdown>
       {{/if}}
@@ -184,7 +183,10 @@
   </div>
 </div>
 
-<AuModal @modalOpen={{this.isDeleteModalOpen}} @closeModal={{this.close}}>
+<AuModal
+  @modalOpen={{this.isDeleteModalOpen}}
+  @closeModal={{fn (mut this.isDeleteModalOpen) false}}
+>
   <:title>{{t "confirmation.deleteCodelistTitle"}}</:title>
   <:body>
     {{t "confirmation.deleteCodelistQuestion"}}

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -51,16 +51,6 @@
         >
           <AuButton
             @skin="link"
-            @icon="export"
-            @iconAlignment="left"
-            role="menuitem"
-            @disabled={{this.isPrivateConceptScheme}}
-            @loadingMessage={{t "messages.loading.downloading"}}
-            {{on "click" this.exportCodelist}}
-          >
-            {{t "actions.exportCodelist"}}
-          </AuButton>
-          <AuButton
             @icon="archive"
             @iconAlignment="left"
             role="menuitem"
@@ -69,6 +59,17 @@
             {{on "click" (fn (mut this.isArchiveModalOpen) true)}}
           >
             {{t "crud.archive"}}
+          </AuButton>
+          <AuButton
+            @skin="link"
+            @icon="export"
+            @iconAlignment="left"
+            role="menuitem"
+            @disabled={{this.isPrivateConceptScheme}}
+            @loadingMessage={{t "messages.loading.downloading"}}
+            {{on "click" this.exportCodelist}}
+          >
+            {{t "actions.exportCodelist"}}
           </AuButton>
         </AuDropdown>
       {{/if}}

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -20,6 +20,8 @@
     <div class="saveSplitButton">
       <AuButton
         id="saveSplitButton_save"
+        @loading={{this.setup.isRunning}}
+        @loadingMessage={{t "messages.loading.isLoading"}}
         @disabled={{this.isSaveDisabled}}
         {{on "click" this.save}}
       >
@@ -73,121 +75,124 @@
     </div>
   </Group>
 </AuToolbar>
-
-<div class="codelijsten__scroll">
-  <span class="au-u-padding">
-    {{#if this.isPrivateConceptScheme}}
-      <AuAlert @title={{"Opgelet"}} @skin={{"warning"}} @icon={{"login"}}>
-        <p>{{t "codelists.alert.genericCodelist"}}</p>
-      </AuAlert>
-    {{else}}
-      {{#if this.isArchivedConceptScheme}}
-        <AuAlert @title={{"Opgelet"}} @skin={{"info"}} @icon={{"archive"}}>
-          <p>{{t "codelists.alert.archivedCodelist"}}</p>
+{{#if this.setup.isRunning}}
+  <AuLoader />
+{{else}}
+  <div class="codelijsten__scroll">
+    <span class="au-u-padding">
+      {{#if this.isPrivateConceptScheme}}
+        <AuAlert @title={{"Opgelet"}} @skin={{"warning"}} @icon={{"login"}}>
+          <p>{{t "codelists.alert.genericCodelist"}}</p>
         </AuAlert>
-      {{/if}}
-    {{/if}}
-
-    <div class="au-u-3-5 au-u-margin-bottom-large">
-      <AuLabel for="input-codelist-name" @required={{true}}>
-        {{t "codelists.nameOfCodelist"}}
-      </AuLabel>
-      <AuInput
-        id="input-codelist-name"
-        @width="block"
-        @error={{this.nameErrorMessage}}
-        @disabled={{this.isReadOnly}}
-        value={{this.codelistName}}
-        {{on "blur" this.handleNameChange}}
-      />
-      {{#if this.nameErrorMessage}}
-        <AuHelpText @error={{true}}>{{this.nameErrorMessage}}</AuHelpText>
-      {{/if}}
-    </div>
-    <div class="au-u-3-5 au-u-margin-bottom-large">
-      {{#if this.isReadOnly}}
-        <p>{{this.codelistDescription}}</p>
       {{else}}
-        <AuLabel for="input-codelist-description" @required={{true}}>
-          {{t "codelists.descriptionOfCodelist"}}
-        </AuLabel>
-        <AuTextarea
-          id="input-codelist-description"
-          @width="block"
-          @error={{this.descriptionErrorMessage}}
-          @disabled={{this.isReadOnly}}
-          value={{this.codelistDescription}}
-          {{on "blur" this.handleDescriptionChange}}
-        />
-        {{#if this.descriptionErrorMessage}}
-          <AuHelpText
-            @error={{true}}
-          >{{this.descriptionErrorMessage}}</AuHelpText>
+        {{#if this.isArchivedConceptScheme}}
+          <AuAlert @title={{"Opgelet"}} @skin={{"info"}} @icon={{"archive"}}>
+            <p>{{t "codelists.alert.archivedCodelist"}}</p>
+          </AuAlert>
         {{/if}}
       {{/if}}
-    </div>
-  </span>
-  <div>
-    <AuTable class="au-u-margin-bottom-small">
-      <:header>
-        <tr>
-          <th>{{t "table.columns.label"}}</th>
-          {{#unless this.isReadOnly}}
-            <th>{{t "table.columns.actions"}}</th>
-          {{/unless}}
-        </tr>
-      </:header>
-      <:body>
-        {{#if this.concepts}}
-          {{#each this.concepts as |concept|}}
-            <tr>
-              {{#if this.isReadOnly}}
-                <td class="au-u-visible-medium-up">
-                  {{concept.label}}</td>
-              {{else}}
-                <td class="au-u-visible-medium-up">
-                  <AuInput
-                    id={{concept.id}}
-                    value={{concept.label}}
-                    {{on "blur" (fn this.handleConceptChange concept)}}
-                  /></td>
-              {{/if}}
-              {{#unless this.isReadOnly}}
-                <td class="au-u-visible-medium-up">
-                  <AuButton
-                    @icon="bin"
-                    @hideText={{true}}
-                    @iconAlignment="left"
-                    @alert={{true}}
-                    @loadingMessage={{t "messages.loading.isDeleting"}}
-                    {{on "click" (fn this.temporaryDeleteConcept concept)}}
-                  >
-                    {{t "crud.delete"}}
-                  </AuButton>
-                </td>
-              {{/unless}}
-            </tr>
-          {{/each}}
+
+      <div class="au-u-3-5 au-u-margin-bottom-large">
+        <AuLabel for="input-codelist-name" @required={{true}}>
+          {{t "codelists.nameOfCodelist"}}
+        </AuLabel>
+        <AuInput
+          id="input-codelist-name"
+          @width="block"
+          @error={{this.nameErrorMessage}}
+          @disabled={{this.isReadOnly}}
+          value={{this.codelistName}}
+          {{on "blur" this.handleNameChange}}
+        />
+        {{#if this.nameErrorMessage}}
+          <AuHelpText @error={{true}}>{{this.nameErrorMessage}}</AuHelpText>
         {{/if}}
-        {{#unless this.isReadOnly}}
+      </div>
+      <div class="au-u-3-5 au-u-margin-bottom-large">
+        {{#if this.isReadOnly}}
+          <p>{{this.codelistDescription}}</p>
+        {{else}}
+          <AuLabel for="input-codelist-description" @required={{true}}>
+            {{t "codelists.descriptionOfCodelist"}}
+          </AuLabel>
+          <AuTextarea
+            id="input-codelist-description"
+            @width="block"
+            @error={{this.descriptionErrorMessage}}
+            @disabled={{this.isReadOnly}}
+            value={{this.codelistDescription}}
+            {{on "blur" this.handleDescriptionChange}}
+          />
+          {{#if this.descriptionErrorMessage}}
+            <AuHelpText
+              @error={{true}}
+            >{{this.descriptionErrorMessage}}</AuHelpText>
+          {{/if}}
+        {{/if}}
+      </div>
+    </span>
+    <div>
+      <AuTable class="au-u-margin-bottom-small">
+        <:header>
           <tr>
-            <td class="au-u-visible-medium-up">
-              <AuButton
-                @skin="secondary"
-                @icon="plus"
-                @iconAlignment="left"
-                {{on "click" this.addNewConcept}}
-              >
-                {{t "codelists.addConcept"}}
-              </AuButton>
-            </td>
-            <td></td>
+            <th>{{t "table.columns.label"}}</th>
+            {{#unless this.isReadOnly}}
+              <th>{{t "table.columns.actions"}}</th>
+            {{/unless}}
           </tr>
-        {{/unless}}
-      </:body>
-    </AuTable>
+        </:header>
+        <:body>
+          {{#if this.concepts}}
+            {{#each this.concepts as |concept|}}
+              <tr>
+                {{#if this.isReadOnly}}
+                  <td class="au-u-visible-medium-up">
+                    {{concept.label}}</td>
+                {{else}}
+                  <td class="au-u-visible-medium-up">
+                    <AuInput
+                      id={{concept.id}}
+                      value={{concept.label}}
+                      {{on "blur" (fn this.handleConceptChange concept)}}
+                    /></td>
+                {{/if}}
+                {{#unless this.isReadOnly}}
+                  <td class="au-u-visible-medium-up">
+                    <AuButton
+                      @icon="bin"
+                      @hideText={{true}}
+                      @iconAlignment="left"
+                      @alert={{true}}
+                      @loadingMessage={{t "messages.loading.isDeleting"}}
+                      {{on "click" (fn this.temporaryDeleteConcept concept)}}
+                    >
+                      {{t "crud.delete"}}
+                    </AuButton>
+                  </td>
+                {{/unless}}
+              </tr>
+            {{/each}}
+          {{/if}}
+          {{#unless this.isReadOnly}}
+            <tr>
+              <td class="au-u-visible-medium-up">
+                <AuButton
+                  @skin="secondary"
+                  @icon="plus"
+                  @iconAlignment="left"
+                  {{on "click" this.addNewConcept}}
+                >
+                  {{t "codelists.addConcept"}}
+                </AuButton>
+              </td>
+              <td></td>
+            </tr>
+          {{/unless}}
+        </:body>
+      </AuTable>
+    </div>
   </div>
-</div>
+{{/if}}
 
 <AuModal
   @modalOpen={{this.isArchiveModalOpen}}

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -61,11 +61,10 @@
           <AuButton
             @icon="archive"
             @iconAlignment="left"
-            @alert={{true}}
             role="menuitem"
             @disabled={{this.isPrivateConceptScheme}}
             @loadingMessage={{t "messages.loading.isArchiving"}}
-            {{on "click" (fn (mut this.isDeleteModalOpen) true)}}
+            {{on "click" (fn (mut this.isArchiveModalOpen) true)}}
           >
             {{t "crud.archive"}}
           </AuButton>
@@ -184,28 +183,29 @@
 </div>
 
 <AuModal
-  @modalOpen={{this.isDeleteModalOpen}}
-  @closeModal={{fn (mut this.isDeleteModalOpen) false}}
+  @modalOpen={{this.isArchiveModalOpen}}
+  @closeModal={{fn (mut this.isArchiveModalOpen) false}}
 >
-  <:title>{{t "confirmation.deleteCodelistTitle"}}</:title>
+  <:title>{{t "confirmation.archiveCodelistTitle"}}</:title>
   <:body>
-    {{t "confirmation.deleteCodelistQuestion"}}
+    {{t "confirmation.archiveCodelistQuestion"}}
   </:body>
   <:footer>
     <AuButtonGroup>
       <AuButton
-        @icon="bin"
+        @icon="archive"
         @iconAlignment="left"
-        @alert={{true}}
-        @loadingMessage="Aan het verwijderen"
-        {{on "click" this.deleteCodelist}}
+        @skin="primary"
+        @loadingMessage={{t "messages.loading.isArchiving"}}
+        @loading={{this.archiveCodelist.isRunning}}
+        {{on "click" (perform this.archiveCodelist)}}
       >
-        {{t "crud.delete"}}
+        {{t "crud.archive"}}
       </AuButton>
       <AuButton
         @skin="secondary"
-        @disabled={{this.delete.isRunning}}
-        {{on "click" (fn (mut this.isDeleteModalOpen) false)}}
+        @disabled={{this.archiveCodelist.isRunning}}
+        {{on "click" (fn (mut this.isArchiveModalOpen) false)}}
       >
         {{t "crud.cancel"}}
       </AuButton>

--- a/app/templates/codelijsten/index.hbs
+++ b/app/templates/codelijsten/index.hbs
@@ -66,6 +66,14 @@
                 @iconAlignment="left"
               >{{t "codelists.types.isPublic"}}
               </AuPill>
+              {{#if conceptScheme.isArchived}}
+                <AuPill
+                  @skin="default"
+                  @icon="archive"
+                  @iconAlignment="left"
+                >{{t "codelists.types.isArchived"}}
+                </AuPill>
+              {{/if}}
             {{else}}
               <AuPill
                 @skin="warning"

--- a/translations/codelists/en-us.yaml
+++ b/translations/codelists/en-us.yaml
@@ -12,6 +12,7 @@ codelists:
   types:
     isPublic: "Custom codelist"
     isPrivate: "Generic"
+    isArchived: "Archived"
   alert:
     genericCodelist: "Generic codelists cannot be edited."
     archivedCodelist: "This codelist is archived."

--- a/translations/codelists/en-us.yaml
+++ b/translations/codelists/en-us.yaml
@@ -14,6 +14,7 @@ codelists:
     isPrivate: "Generic"
   alert:
     genericCodelist: "Generic codelists cannot be edited."
+    archivedCodelist: "This codelist is archived."
 
 confirmation:
   deleteCodelistTitle: "Delete codelist?"

--- a/translations/codelists/en-us.yaml
+++ b/translations/codelists/en-us.yaml
@@ -18,6 +18,8 @@ codelists:
 confirmation:
   deleteCodelistTitle: "Delete codelist?"
   deleteCodelistQuestion: "Are you sure you want to delete this codelist? This action is permanent."
+  archiveCodelistTitle: "Archive codelist?"
+  archiveCodelistQuestion: "Are you sure you want to archive this codelist?"
 
 navigation:
   backToCodelists: "Back to codelists"

--- a/translations/codelists/nl-be.yaml
+++ b/translations/codelists/nl-be.yaml
@@ -18,6 +18,8 @@ codelists:
 confirmation:
   deleteCodelistTitle: "Codelijst verwijderen?"
   deleteCodelistQuestion: "Bent u zeker dat u deze codelijst wilt verwijderen? Deze actie is permanent."
+  archiveCodelistTitle: "Codelijst archiveren?"
+  archiveCodelistQuestion: "Bent u zeker dat u deze codelijst wilt archiveren?"
 
 navigation:
   backToCodelists: "Terug naar codelijsten"

--- a/translations/codelists/nl-be.yaml
+++ b/translations/codelists/nl-be.yaml
@@ -12,6 +12,7 @@ codelists:
   types:
     isPublic: "Eigen codelijst"
     isPrivate: "Generiek"
+    isArchived: "Ge-archiveerd"
   alert:
     genericCodelist: "Generieke codelijsten kunnen niet aangepast worden."
     archivedCodelist: "Deze codelijst is ge-archiveerd."

--- a/translations/codelists/nl-be.yaml
+++ b/translations/codelists/nl-be.yaml
@@ -12,7 +12,7 @@ codelists:
   types:
     isPublic: "Eigen codelijst"
     isPrivate: "Generiek"
-    isArchived: "Ge-archiveerd"
+    isArchived: "Gearchiveerd"
   alert:
     genericCodelist: "Generieke codelijsten kunnen niet aangepast worden."
     archivedCodelist: "Deze codelijst is ge-archiveerd."

--- a/translations/codelists/nl-be.yaml
+++ b/translations/codelists/nl-be.yaml
@@ -14,6 +14,7 @@ codelists:
     isPrivate: "Generiek"
   alert:
     genericCodelist: "Generieke codelijsten kunnen niet aangepast worden."
+    archivedCodelist: "Deze codelijst is ge-archiveerd."
 
 confirmation:
   deleteCodelistTitle: "Codelijst verwijderen?"

--- a/translations/main/en-us.yaml
+++ b/translations/main/en-us.yaml
@@ -14,6 +14,7 @@ userTests:
 crud:
   save: "Save"
   delete: "Delete"
+  archive: "Archive"
   update: "Update"
   cancel: "Cancel"
   reset: "Reset"

--- a/translations/main/nl-be.yaml
+++ b/translations/main/nl-be.yaml
@@ -14,6 +14,7 @@ userTests:
 crud:
   save: "Bewaar"
   delete: "Verwijder"
+  archive: "Archiveren"
   update: "Bijwerken"
   cancel: "Annuleer"
   reset: "Reset"

--- a/translations/messages/en-us.yaml
+++ b/translations/messages/en-us.yaml
@@ -34,6 +34,7 @@ messages:
     isSaving: "Saving"
     isLoading: "Loading..."
     isDeleting: "Deleting"
+    isArchiving: "Archiving"
 
 confirmation:
   deleteTitle: "Delete form?"

--- a/translations/messages/en-us.yaml
+++ b/translations/messages/en-us.yaml
@@ -5,6 +5,7 @@ messages:
     characters: "Characters"
     deleted: "Verwijderd"
     upToDate: "Up-to-date"
+    archived: "Archived"
   error:
     invalidTemplatePath: "The selected template ({templateLabel}) has an invalid path configured"
     couldNotFetchFormWithId: "Could not find form with id: {id}"

--- a/translations/messages/nl-be.yaml
+++ b/translations/messages/nl-be.yaml
@@ -5,6 +5,7 @@ messages:
     characters: "Karakters"
     deleted: "Verwijderd"
     upToDate: "Up-to-date"
+    archived: "Ge-archiveerd"
   error:
     invalidTemplatePath: "De geselecteerde template ({templateLabel}) heeft geen correct path."
     couldNotFetchFormWithId: "Kon formulier met id: {id} niet vinden"

--- a/translations/messages/nl-be.yaml
+++ b/translations/messages/nl-be.yaml
@@ -34,6 +34,7 @@ messages:
     isSaving: "Bewaren"
     isLoading: "Aan het laden..."
     isDeleting: "Aan het verwijderen"
+    isArchiving: "Aan het archiveren"
 
 confirmation:
   deleteTitle: "Formulier verwijderen?"


### PR DESCRIPTION
## ID
 [SFB-168](https://binnenland.atlassian.net/browse/SFB-168)

 ## Description

Users can create custom codelists now. As other users can also make use of these codelists it's better to archive the codelists that to delete it. This makes it possible to restore the codelist if we want to.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Create a codelist
2. Archive the codelist
3. You should see the archived codelist in the overview list but with a new tag "Ge-archiveerd"
4. When opening the archived list you will only be able to view the codelist

 ## Links to other PR's

 -  https://github.com/lblod/app-form-builder/pull/9