### PR TITLE
SFB-102: skip test form overview

### DIFF
--- a/app/templates/user-tests/edit.hbs
+++ b/app/templates/user-tests/edit.hbs
@@ -11,7 +11,7 @@
 
         <div class="au-c-toolbar__group">
           <AuButtonGroup>
-            <AuLink @route="user-tests.index" @icon="arrow-left" @skin="button-secondary">{{t "navigation.toOverviewTestForms"}}</AuLink>
+            <AuLink @route="index" @icon="arrow-left" @skin="button-secondary">{{t "navigation.backToFormOverview"}}</AuLink>
           </AuButtonGroup>
         </div>
       </div>

--- a/app/templates/user-tests/edit.hbs
+++ b/app/templates/user-tests/edit.hbs
@@ -8,23 +8,27 @@
           </AuHeading>
         </div>
 
-
         <div class="au-c-toolbar__group">
           <AuButtonGroup>
-            <AuLink @route="index" @icon="arrow-left" @skin="button-secondary">{{t "navigation.backToFormOverview"}}</AuLink>
+            <AuLink
+              @route="index"
+              @icon="arrow-left"
+              @skin="button-secondary"
+            >{{t "navigation.backToFormOverview"}}</AuLink>
           </AuButtonGroup>
         </div>
       </div>
       <div class="au-c-body-container au-c-body-container--scroll">
         <div class="au-o-box">
           <RdfForm
-                  @groupClass="au-o-grid__item au-u-1-1 au-u-1-2@medium au-u-1-3@large"
-                  @form={{this.model.form}}
-                  @graphs={{this.model.graphs}}
-                  @sourceNode={{this.model.node}}
-                  @formStore={{this.model.graph}}
-                  @show={{false}}
-                  @forceShowErrors={{false}} />
+            @groupClass="au-o-grid__item au-u-1-1 au-u-1-2@medium au-u-1-3@large"
+            @form={{this.model.form}}
+            @graphs={{this.model.graphs}}
+            @sourceNode={{this.model.node}}
+            @formStore={{this.model.graph}}
+            @show={{false}}
+            @forceShowErrors={{false}}
+          />
         </div>
       </div>
     </div>
@@ -34,32 +38,53 @@
                   @loading={{if this.submit.isRunning "true"}}
           {{on "click" (perform this.submit)}}>Verstuur (en terug naar overzicht)
         </AuButton> --}}
-        <AuButton @disabled={{if (or this.save.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
-                  @loading={{if this.save.isRunning "true"}}
-                  @icon={{if this.recentlySaved "check"}}
-                  @iconAlignment={{if this.recentlySaved "left"}}
-          {{on "click" (perform this.save)}}>
+        <AuButton
+          @disabled={{if
+            (or this.save.isRunning this.submit.isRunning this.delete.isRunning)
+            "true"
+          }}
+          @loading={{if this.save.isRunning "true"}}
+          @icon={{if this.recentlySaved "check"}}
+          @iconAlignment={{if this.recentlySaved "left"}}
+          {{on "click" (perform this.save)}}
+        >
           {{t "crud.save"}}
         </AuButton>
-        <AuLink @route="user-tests.index" @skin="secondary">{{t "crud.cancel"}}</AuLink>
+        <AuLink @route="user-tests.index" @skin="secondary">{{t
+            "crud.cancel"
+          }}</AuLink>
       </Group>
 
       {{#unless this.model.submitted}}
         <Group>
-          <AuButton @disabled={{if (or this.save.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
-                    @loading={{if this.reset.isRunning "true"}}
-                    @skin="link"
-                    @alert={{"true"}}
-                    @icon="renew"
-            {{on "click" (perform this.reset)}}>
+          <AuButton
+            @disabled={{if
+              (or
+                this.save.isRunning this.submit.isRunning this.delete.isRunning
+              )
+              "true"
+            }}
+            @loading={{if this.reset.isRunning "true"}}
+            @skin="link"
+            @alert={{"true"}}
+            @icon="renew"
+            {{on "click" (perform this.reset)}}
+          >
             {{t "crud.reset"}}
           </AuButton>
-          <AuButton @disabled={{if (or this.save.isRunning this.submit.isRunning this.delete.isRunning) "true"}}
-                    @loading={{if this.delete.isRunning "true"}}
-                    @skin="link"
-                    @alert={{"true"}}
-                    @icon="bin"
-            {{on "click" (perform this.delete)}}>
+          <AuButton
+            @disabled={{if
+              (or
+                this.save.isRunning this.submit.isRunning this.delete.isRunning
+              )
+              "true"
+            }}
+            @loading={{if this.delete.isRunning "true"}}
+            @skin="link"
+            @alert={{"true"}}
+            @icon="bin"
+            {{on "click" (perform this.delete)}}
+          >
             {{t "crud.delete"}}
           </AuButton>
         </Group>


### PR DESCRIPTION
## ID
 [SFB-102](https://binnenland.atlassian.net/browse/SFB-102)

 ## Description

A ticket from the testers: it is strange that you go to the user-test overview page when clicking back in the user-test detail screen, This because there are no other actions in the user-test overview screen to do than. This is a double click back that is not needed. 

Update the route and text of the button to go to the forms overview page.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. forms overview, select a `voorbeeld` of a form
2. Press the top right `terug naar formulieren` 
3. It should send you back to the forms overview instead of the user-test overview

 ## Links to other PR's

 - /