### PR TITLE
SFB-174: Update the breadcrums bar 

### DIFF
--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -1,11 +1,22 @@
 <nav>
   <div class="au-c-app-chrome">
-    <AuToolbar @size="small" class="au-u-padding-bottom-none" as |Group|>
+    <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
       <Group>
-        <AuLink @route="index" @skin="secondary" @icon="arrow-left">
-          {{t "navigation.backToFormOverview"}}
-        </AuLink>
-        <span class="au-c-app-chrome__entity">{{@model.label}}</span>
+        <ul class="au-c-list-horizontal au-c-list-horizontal--small">
+          <li class="au-c-list-horizontal__item">
+            <AuLink
+              @route="index"
+              @skin="primary"
+              @icon="arrow-left"
+              @iconAlignment="left"
+            >
+              {{t "navigation.backToFormOverview"}}
+            </AuLink>
+          </li>
+          <li class="au-c-list-horizontal__item">
+            {{@model.label}}
+          </li>
+        </ul>
       </Group>
     </AuToolbar>
     <AuToolbar @size="small" class="au-u-padding-top-none" as |Group|>

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -1,26 +1,22 @@
 <nav>
   <div class="au-c-app-chrome">
-    <AuToolbar @size="medium" @skin="tint" @border="bottom" as |Group|>
+    <AuToolbar
+      @size="small"
+      class="au-u-padding-top-none au-u-padding-bottom-none"
+      as |Group|
+    >
       <Group>
-        <ul class="au-c-list-horizontal au-c-list-horizontal--small">
-          <li class="au-c-list-horizontal__item">
-            <AuLink
-              @route="index"
-              @skin="primary"
-              @icon="arrow-left"
-              @iconAlignment="left"
-            >
-              {{t "navigation.backToFormOverview"}}
-            </AuLink>
-          </li>
-          <li class="au-c-list-horizontal__item">
-            {{@model.label}}
-          </li>
-        </ul>
-      </Group>
-    </AuToolbar>
-    <AuToolbar @size="small" class="au-u-padding-top-none" as |Group|>
-      <Group>
+        <div>
+          <AuLink
+            @route="index"
+            @skin="primary"
+            @icon="arrow-left"
+            @iconAlignment="left"
+            @hideText={{true}}
+          >
+            {{t "navigation.backToFormOverview"}}
+          </AuLink>
+        </div>
         <div>
           {{#if @formChanged}}
             <AuPill @skin="warning" @icon="alert-triangle">
@@ -62,7 +58,6 @@
               {{on "click" (fn (mut this.isEditingName) true)}}
             />
           {{/if}}
-
         </div>
       </Group>
       <Group class="au-c-toolbar__group--actions">

--- a/app/components/toolbar.hbs
+++ b/app/components/toolbar.hbs
@@ -7,16 +7,6 @@
         </AuLink>
         <span class="au-c-app-chrome__entity">{{@model.label}}</span>
       </Group>
-      <Group>
-        <ul class="au-c-list-horizontal au-u-padding-right-tiny">
-          <li class="au-c-list-horizontal__item">
-            <span class="au-c-app-chrome__status">
-              {{t "toolbar.savedOn"}}
-              {{or @model.modified @model.created}}
-            </span>
-          </li>
-        </ul>
-      </Group>
     </AuToolbar>
     <AuToolbar @size="small" class="au-u-padding-top-none" as |Group|>
       <Group>

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -11,8 +11,8 @@
           @iconAlignment="left"
         >{{t "navigation.backToCodelists"}}</AuLink>
       </li>
-      <li class="au-c-list-horizontal__item au-u-bold">
-        {{t "codelists.detailTitle"}}
+      <li class="au-c-list-horizontal__item">
+        {{this.codelistName}}
       </li>
     </ul>
   </Group>

--- a/app/templates/codelijsten/index.hbs
+++ b/app/templates/codelijsten/index.hbs
@@ -11,7 +11,7 @@
           @iconAlignment="left"
         >{{t "navigation.backToFormBuilder"}}</AuLink>
       </li>
-      <li class="au-c-list-horizontal__item au-u-bold">
+      <li class="au-c-list-horizontal__item">
         {{t "navigation.tabs.codelists"}}
       </li>
     </ul>

--- a/translations/codelists/en-us.yaml
+++ b/translations/codelists/en-us.yaml
@@ -2,7 +2,6 @@ codelists:
   addConcept: "Add concept to the list"
   nameOfCodelist: "Name of codelist"
   descriptionOfCodelist: "Description"
-  detailTitle: "Codelist detail"
   createCodelist: "Create a codelist"
   howToUse: "How to use the concept scheme:"
   chooseList: "Choose a concept scheme whose contents you want to view."

--- a/translations/codelists/nl-be.yaml
+++ b/translations/codelists/nl-be.yaml
@@ -2,7 +2,6 @@ codelists:
   addConcept: "Voeg een concept toe aan de lijst"
   nameOfCodelist: "Naam van de codelijst"
   descriptionOfCodelist: "Beschrijving"
-  detailTitle: "Codelijst detail"
   createCodelist: "Maak een codelijst"
   howToUse: "Hoe de concept scheme gebruiken:"
   chooseList: "Kies een concept scheme waarvan u de inhoud wil bekijken"

--- a/translations/main/en-us.yaml
+++ b/translations/main/en-us.yaml
@@ -44,7 +44,6 @@ createForm:
 
 # Components #
 toolbar:
-  savedOn: "Saved on"
   exportCode: "Export code"
   unSavedChanges: "Unsaved changes"
   formUpToDate: "Form up-to-date"

--- a/translations/main/nl-be.yaml
+++ b/translations/main/nl-be.yaml
@@ -44,7 +44,6 @@ createForm:
 
 # Components #
 toolbar:
-  savedOn: "Bewaard op"
   exportCode: "Exporteer code"
   unSavedChanges: "Aanpassingen nog niet bewaard"
   formUpToDate: "Formulier up-to-date"


### PR DESCRIPTION
## ID
 [SFB-174](https://binnenland.atlassian.net/browse/SFB-174)

 ## Description

The breadcrumsbar looks off. Update the bar to look the same as in [appuniversum breadcrums](https://appuniversum.github.io/ember-appuniversum/?path=/story/templates-app-with-breadcrumbs--page) 

Also remove the _Bewaard op ..._ text in the toolbar.

 ## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [x] Other

 ## How to test

1. Is the _Bewaard op .._ text still visible in the toolbar? 
2. Design of the breadcrums bar is the same as in the appuniversum addon

 ## Links to other PR's

 - /