### PR TITLE
SFB-209: limit export and archive codelist functionality

### DIFF
--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -59,6 +59,14 @@ export default class CodelijstenEditController extends Controller {
     return this.conceptScheme.isArchived;
   }
 
+  get canArchiveCodelist() {
+    return !this.isPrivateConceptScheme;
+  }
+
+  get canExportCodelist() {
+    return !this.isPrivateConceptScheme;
+  }
+
   setup = restartableTask(async (conceptSchemeId) => {
     this.conceptScheme = await this.getConceptSchemeById(conceptSchemeId);
     this.setValuesFromConceptscheme();
@@ -411,5 +419,20 @@ export default class CodelijstenEditController extends Controller {
         id: conceptSchemeId,
       });
     }
+  }
+
+  @action
+  opposite(boolean) {
+    if (typeof boolean !== 'boolean') {
+      showErrorToasterMessage(
+        this.toaster,
+        this.intl.t('messages.error.valueMustBeBoolean', {
+          value: boolean,
+        })
+      );
+      return false;
+    }
+
+    return !boolean;
   }
 }

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -60,7 +60,7 @@
             @icon="archive"
             @iconAlignment="left"
             role="menuitem"
-            @disabled={{this.isPrivateConceptScheme}}
+            @disabled={{this.opposite this.canArchiveCodelist}}
             @loadingMessage={{t "messages.loading.isArchiving"}}
             {{on "click" (fn (mut this.isArchiveModalOpen) true)}}
           >
@@ -71,7 +71,7 @@
             @icon="export"
             @iconAlignment="left"
             role="menuitem"
-            @disabled={{this.isPrivateConceptScheme}}
+            @disabled={{this.opposite this.canExportCodelist}}
             @loadingMessage={{t "messages.loading.downloading"}}
             {{on "click" this.exportCodelist}}
           >

--- a/translations/messages/en-us.yaml
+++ b/translations/messages/en-us.yaml
@@ -14,6 +14,7 @@ messages:
     cannotAddValidationsToEmptyForm: "Could not add validations to an empty form"
     duplicateValidationType: "Validation type {type} is duplicate"
     couldNotGetFormIdIsNotSet: "Could not get form id. Id is never set."
+    valueMustBeBoolean: "The given value is not a boolean {value}"
   success:
     formCreated: "Form created successfully"
     formUpdated: "Form updated"

--- a/translations/messages/nl-be.yaml
+++ b/translations/messages/nl-be.yaml
@@ -14,6 +14,7 @@ messages:
     cannotAddValidationsToEmptyForm: "Kan geen validaties toevoegen aan een leeg formulier"
     duplicateValidationType: "Validatietype {type} is duplicaat"
     couldNotGetFormIdIsNotSet: "Kan form id niet vinden. Id niet ingesteld."
+    valueMustBeBoolean: "The gegeven waarde is geen boolean waarde {value}"
   success:
     formCreated: "Formulier succesvol aangemaakt"
     formUpdated: "Formulier bijgewerkt"


### PR DESCRIPTION
## ID
  [SFB-209](https://binnenland.atlassian.net/browse/SFB-209)

 ## Description

* When creating a new codelist a new concept-scheme is created in the database
* The user has the possibility to archive or export the codelists even before they have filled in a field

Limit the functionality so the user cannot do these actions when just created

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

When creatin a new codelist you are not able to directly archive or export the codelist

 ## Links to other PR's

 - /