### PR TITLE
SFB-220: test form code manager service

### DIFF
--- a/app/services/form-code-manager.js
+++ b/app/services/form-code-manager.js
@@ -58,9 +58,14 @@ export default class FormCodeManagerService extends Service {
     );
   }
 
+  resetVersions() {
+    this.latestVersion = this.startVersion;
+    this.referenceVersion = this.startVersion;
+  }
+
   clearHistory() {
     this.formCodeHistory = [];
-    this.latestVersion = this.startVersion;
+    this.resetVersions();
   }
 
   reset() {

--- a/tests/unit/services/form-code-manager-test.js
+++ b/tests/unit/services/form-code-manager-test.js
@@ -187,4 +187,24 @@ module('Unit | Service | form-code-manager', function (hooks) {
     assert.notOk(formCodeManager.isTtlTheSameAsLatest('latest TTL CODE'));
     assert.ok(formCodeManager.isTtlTheSameAsLatest(latestTtl));
   });
+
+  test('The form input data is not set initially', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+
+    assert.deepEqual(formCodeManager.formInputDataTtl, null);
+  });
+
+  test('The form input data can be set and get after', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+    const inputData = 'form input data';
+
+    assert.deepEqual(formCodeManager.formInputDataTtl, null);
+
+    formCodeManager.setFormInputDataTtl(inputData);
+    assert.deepEqual(formCodeManager.formInputDataTtl, inputData);
+    assert.deepEqual(
+      formCodeManager.getInputDataForLatestFormVersion(),
+      inputData
+    );
+  });
 });

--- a/tests/unit/services/form-code-manager-test.js
+++ b/tests/unit/services/form-code-manager-test.js
@@ -4,9 +4,94 @@ import { setupTest } from 'frontend-form-builder/tests/helpers';
 module('Unit | Service | form-code-manager', function (hooks) {
   setupTest(hooks);
 
-  // TODO: Replace this with your real tests.
+  const startVersion = -1;
+  const emptyArray = [];
+
   test('it exists', function (assert) {
     let service = this.owner.lookup('service:form-code-manager');
     assert.ok(service);
+  });
+
+  test('The start version is -1', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+
+    assert.deepEqual(formCodeManager.startVersion, startVersion);
+    assert.deepEqual(formCodeManager.latestVersion, startVersion);
+    assert.deepEqual(formCodeManager.referenceVersion, startVersion);
+  });
+
+  test('The formId is not set initially', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+    const formIdIsNull = null;
+
+    assert.deepEqual(formCodeManager.formId, formIdIsNull);
+    assert.notOk(formCodeManager.isFormIdSet());
+  });
+
+  test('When no formId is set it throws an error', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+    let intl = this.owner.lookup('service:intl');
+    const formIdIsNull = null;
+
+    assert.deepEqual(formCodeManager.formId, formIdIsNull);
+    assert.throws(
+      () => formCodeManager.getFormId(),
+      intl.t('messages.error.couldNotGetFormIdIsNotSet')
+    );
+  });
+
+  test('Can set a form id', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+    const formId = 'identifier';
+
+    formCodeManager.setFormId(formId);
+    assert.deepEqual(formCodeManager.formId, formId);
+    assert.deepEqual(formCodeManager.getFormId(), formId);
+    assert.ok(formCodeManager.isFormIdSet());
+  });
+
+  test('Reset versions will set all versions to the startVersion', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+    formCodeManager.latestVersion = 3;
+    formCodeManager.referenceVersion = 3;
+
+    formCodeManager.resetVersions();
+
+    assert.deepEqual(formCodeManager.latestVersion, startVersion);
+    assert.deepEqual(formCodeManager.referenceVersion, startVersion);
+  });
+
+  test('The form code history is empty initially', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+
+    assert.deepEqual(formCodeManager.formCodeHistory, emptyArray);
+  });
+
+  test('ClearHistory will empty the history array and sets the versions to startVersion', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+    formCodeManager.formCodeHistory = ['item'];
+
+    formCodeManager.clearHistory();
+
+    assert.deepEqual(formCodeManager.formCodeHistory, emptyArray);
+    assert.deepEqual(formCodeManager.latestVersion, startVersion);
+    assert.deepEqual(formCodeManager.referenceVersion, startVersion);
+  });
+
+  test('Clear history will not reset the form id', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+    formCodeManager.setFormId('identifier');
+    formCodeManager.clearHistory();
+
+    assert.ok(formCodeManager.isFormIdSet);
+  });
+
+  test('Reset will cleanup the history and reset the versions and set the formId to null', function (assert) {
+    let formCodeManager = this.owner.lookup('service:form-code-manager');
+
+    assert.deepEqual(formCodeManager.formCodeHistory, emptyArray);
+    assert.deepEqual(formCodeManager.latestVersion, startVersion);
+    assert.deepEqual(formCodeManager.referenceVersion, startVersion);
+    assert.notOk(formCodeManager.isFormIdSet());
   });
 });


### PR DESCRIPTION
## ID
 [SFB-220](https://binnenland.atlassian.net/browse/SFB-220)

 ## Description

While looking for a good test strategy I found out that the form code manager what is used as a main service in the form builder for keeping track of form ttl changes is not tested yet. In this PR you can find the tests for the  service

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

Run the ember test. command: `ember test --server --filter="Unit | Service | form-code-manager"`

 ## Links to other PR's

 - /