### PR TITLE
SFB-226: Remove query with size 999

### DIFF
--- a/app/components/concept-scheme-uri-selector.hbs
+++ b/app/components/concept-scheme-uri-selector.hbs
@@ -4,6 +4,8 @@
     @options={{this.options}}
     @selected={{this.selected}}
     @onChange={{this.setSelected}}
+    @searchEnabled={{true}}
+    @searchField="label"
     as |conceptScheme|
   >
     {{conceptScheme.label}}

--- a/app/components/concept-scheme-uri-selector.js
+++ b/app/components/concept-scheme-uri-selector.js
@@ -2,8 +2,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { service } from '@ember/service';
-import { PAGE_SIZE_TO_GET_ALL } from '../utils/constants';
 import { sortObjectsOnProperty } from '../utils/sort-object-on-property';
+import { queryAllItemsInStorePerPage } from '../utils/query-all-items-in-store-per-page';
 
 export default class ConceptSchemeUriSelectorComponent extends Component {
   @service store;
@@ -50,13 +50,12 @@ export default class ConceptSchemeUriSelectorComponent extends Component {
 
   @action
   async loadOptions() {
-    const conceptSchemes = await this.store.query('concept-scheme', {
-      page: {
-        size: PAGE_SIZE_TO_GET_ALL,
-      },
-    });
+    const conceptSchemes = await queryAllItemsInStorePerPage(
+      this.store,
+      'concept-scheme'
+    );
 
-    const notArchivedConceptSchemes = [...conceptSchemes].filter(
+    const notArchivedConceptSchemes = conceptSchemes.filter(
       (scheme) => !scheme.isArchived
     );
 

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -1,7 +1,6 @@
 export const DESCRIPTION_NOT_USED_PLACEHOLDER = '';
 export const NAME_INPUT_CHAR_LIMIT = 120;
 export const DESCRIPTION_INPUT_CHAR_LIMIT = 500;
-export const PAGE_SIZE_TO_GET_ALL = 999;
 export const INPUT_DEBOUNCE_MS = 500;
 export const SHACL_SEVERITY_TYPE = {
   error: 'Violation',

--- a/app/utils/query-all-items-in-store-per-page.js
+++ b/app/utils/query-all-items-in-store-per-page.js
@@ -1,0 +1,29 @@
+export async function queryAllItemsInStorePerPage(store, model) {
+  const pageSize = 20;
+  let allItemsGet = false;
+  let currentPage = 0;
+  const items = [];
+  do {
+    let results = [];
+    try {
+      results = await store.query(model, {
+        page: { number: currentPage, size: pageSize },
+      });
+    } catch (error) {
+      console.error(`Caught:`, error);
+      allItemsGet = true;
+
+      return items;
+    }
+
+    items.push(...results);
+
+    if (results.length < pageSize) {
+      allItemsGet = true;
+    } else {
+      currentPage++;
+    }
+  } while (!allItemsGet);
+
+  return items;
+}


### PR DESCRIPTION
## ID
 [SFB-226](https://binnenland.atlassian.net/browse/SFB-226)

 ## Description

When going to the codelists page it returns a 500. The reason is why is unsure yet.

As from the beginning of the concept scheme selector a call was done towards the database to get all the concept schemes in the database. This call was done by adding a parameter `page: { size: 9999 }`. This is not great as if ever the list becomes larger than 9999 it will not show the latest conceptschemes. I updated the call so all the items are get per page. This will make that the amount of calls will increase to get the information, everything will always be get from the database and there is no call anymore that uses a constant of 9999 to get all the items in the store. It does not feel the correct way but it's already better than the implementation of today. If someone else comes up with a better way please just tell me a way.


 ## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [x] Breaking change
 - [ ] Other

 ## How to test

1. add a dropdown to the form
2. Go to the configuration tab and select a codelist
3. All of the codelists should be available

 ## Links to other PR's

 - /