### PR TITLE
SFB-227: after choosing validation, the type is locked in

### DIFF
--- a/app/components/rdf-form-fields/validation-concept-scheme-selector.hbs
+++ b/app/components/rdf-form-fields/validation-concept-scheme-selector.hbs
@@ -19,7 +19,7 @@
     @allowClear={{true}}
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten gevonden"
-    @disabled={{@show}}
+    @disabled={{if (and this.selectedValidationType (not @show)) true}}
     data-test-field-uri={{@field.uri.value}}
     as |concept|
   >


### PR DESCRIPTION
## ID
SFB-227

 ## Description

This solves the problem where the components under validation type selector didn't update. Instead of just changing, you delete the validation and choose an new one, where a new message field etc is generated after choosing the validation.

 ## Type of change

 - [ ] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test


