### PR TITLE
SFB-231: fix shacl warning on resultMessage

### DIFF
--- a/public/SHACL/V2/max-characters-constraint.ttl
+++ b/public/SHACL/V2/max-characters-constraint.ttl
@@ -29,7 +29,16 @@ form:MaxLength
     [
       sh:path sh:resultMessage ;
       sh:maxCount 1 ;
-      sh:datatype xsd:string ;
-      sh:message "Er mag maar 1 error bericht op form:Maxlength validatie staan."@nl ;
+      sh:message "Er mag maar 1 error bericht op form:Requiredconstraint validatie staan."@nl ;
       sh:severity sh:Warning;
-    ].
+    ],
+    [
+      sh:path sh:resultMessage ;
+      sh:nodeKind sh:Literal ;
+      sh:or (
+        [ sh:datatype xsd:string ]
+        [ sh:datatype rdf:langString ]
+      ) ;
+      sh:message "sh:resultMessage moet een string of taal-getagde string zijn."@nl ;
+      sh:severity sh:Warning ;
+    ] .

--- a/public/SHACL/V2/repositories.ttl
+++ b/public/SHACL/V2/repositories.ttl
@@ -5,3 +5,4 @@
 @prefix nodes: <http://data.lblod.info/form-data/nodes/>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/public/SHACL/V2/required-constraint.ttl
+++ b/public/SHACL/V2/required-constraint.ttl
@@ -22,7 +22,16 @@ form:RequiredConstraint
     [
       sh:path sh:resultMessage ;
       sh:maxCount 1 ;
-      sh:datatype xsd:string ;
       sh:message "Er mag maar 1 error bericht op form:Requiredconstraint validatie staan."@nl ;
       sh:severity sh:Warning;
-    ].
+    ],
+    [
+      sh:path sh:resultMessage ;
+      sh:nodeKind sh:Literal ;
+      sh:or (
+        [ sh:datatype xsd:string ]
+        [ sh:datatype rdf:langString ]
+      ) ;
+      sh:message "sh:resultMessage moet een string of taal-getagde string zijn."@nl ;
+      sh:severity sh:Warning ;
+  ] .


### PR DESCRIPTION
## ID
SFB-231

 ## Description

When adding a resultMessage to a validation it gave a wrong warning.

 ## Type of change

 - [x] Bug fix
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

If you add 1 string or langString it shouldn't give a warning. If you add more than 1 or the wrong datatype it will give a warning.