### PR TITLE
SFB-234: add exact value constraint shacl shape

### DIFF
--- a/app/utils/SHACL/shacl-validate-ttl-code.js
+++ b/app/utils/SHACL/shacl-validate-ttl-code.js
@@ -33,6 +33,7 @@ async function getAllShapesTtl() {
     getLocalFileContentAsText('/SHACL/V2/required-constraint.ttl'),
     getLocalFileContentAsText('/SHACL/V2/max-characters-constraint.ttl'),
     getLocalFileContentAsText('/SHACL/V2/positive-number-constraint.ttl'),
+    getLocalFileContentAsText('/SHACL/V2/exact-value-constraint.ttl'),
   ]);
 
   return allShapes.join('\n');

--- a/public/SHACL/V2/exact-value-constraint.ttl
+++ b/public/SHACL/V2/exact-value-constraint.ttl
@@ -22,11 +22,17 @@ form:ExactValueConstraint
     ],
     [
       sh:path form:customValue ;
-      sh:datatype xsd:string ;
       sh:minCount 1 ;
       sh:maxCount 1 ;
       sh:message "form:customValue is verplicht voor dit validatie type."@nl ;
       sh:severity sh:Violation;
+    ],
+    [
+      sh:path form:customValue ;
+      sh:datatype xsd:string ;
+      sh:nodeKind sh:Literal ;
+      sh:message "form:customValue moet een string zijn."@nl ;
+      sh:severity sh:Warning;
     ],
     [
       sh:path sh:resultMessage ;

--- a/public/SHACL/V2/exact-value-constraint.ttl
+++ b/public/SHACL/V2/exact-value-constraint.ttl
@@ -1,0 +1,46 @@
+#################################################
+# Exact value constraint shape for V2 forms ##
+#################################################
+
+form:ExactValueConstraint
+  a sh:NodeShape ;
+  sh:targetClass form:ExactValueConstraint ;
+  sh:property
+    [
+      sh:path form:grouping ;
+      sh:hasValue form:MatchSome ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:message "form:Grouping moet de waarde form:MatchSome zijn."@nl ;
+      sh:severity sh:Warning ;
+    ],
+    [
+      sh:path sh:path ;
+      sh:minCount 1 ;
+      sh:message "sh:path moet verwijzen naar het subject waar het op toegepast wordt."@nl ;
+      sh:severity sh:Warning ;
+    ],
+    [
+      sh:path form:customValue ;
+      sh:datatype xsd:string ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:message "form:customValue is verplicht voor dit validatie type."@nl ;
+      sh:severity sh:Violation;
+    ],
+    [
+      sh:path sh:resultMessage ;
+      sh:maxCount 1 ;
+      sh:message "Er mag maar 1 error bericht op form:ExactValueConstraint validatie staan."@nl ;
+      sh:severity sh:Warning;
+    ],
+    [
+      sh:path sh:resultMessage ;
+      sh:nodeKind sh:Literal ;
+      sh:or (
+        [ sh:datatype xsd:string ]
+        [ sh:datatype rdf:langString ]
+      ) ;
+      sh:message "sh:resultMessage moet een string of taal-getagde string zijn."@nl ;
+      sh:severity sh:Warning ;
+    ] .

--- a/tests/unit/SHACL/V2/exact-value-constraint-test.js
+++ b/tests/unit/SHACL/V2/exact-value-constraint-test.js
@@ -1,0 +1,135 @@
+import { shaclValidateTtlCode } from 'frontend-form-builder/utils/SHACL/shacl-validate-ttl-code';
+import { module, test } from 'qunit';
+
+module('Unit | SHACL | V2 | Exact value constraint', function () {
+  test('is build up correctly', async function (assert) {
+    const ttlCode = `
+        @prefix : <#> .
+        @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+        @prefix nodes: <http://data.lblod.info/form-data/nodes/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+          a form:ExactValueConstraint;
+          form:customValue "12";
+          form:grouping form:MatchSome;
+          sh:order 1;
+          sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+          sh:resultMessage "Dit veld is verplicht" .
+      `;
+
+    const report = await shaclValidateTtlCode(ttlCode);
+
+    assert.true(report.conforms);
+  });
+  test('grouping type must be MatchSome NOT MatchEvery', async function (assert) {
+    const ttlCode = `
+        @prefix : <#> .
+        @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+        @prefix nodes: <http://data.lblod.info/form-data/nodes/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+          a form:ExactValueConstraint;
+          form:customValue "12";
+          form:grouping form:MatchEvery;
+          sh:order 1;
+          sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+          sh:resultMessage "Dit veld is verplicht" .
+      `;
+
+    const report = await shaclValidateTtlCode(ttlCode);
+
+    assert.false(report.conforms);
+  });
+  test('sh:resultMessage must be a string not an integer', async function (assert) {
+    const ttlCode = `
+        @prefix : <#> .
+        @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+        @prefix nodes: <http://data.lblod.info/form-data/nodes/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+          a form:ExactValueConstraint;
+          form:customValue "12";
+          form:grouping form:MatchSome;
+          sh:order 1;
+          sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+          sh:resultMessage 123 .
+      `;
+
+    const report = await shaclValidateTtlCode(ttlCode);
+
+    assert.false(report.conforms);
+  });
+  test('sh:path is missing in constraint', async function (assert) {
+    const ttlCode = `
+        @prefix : <#> .
+        @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+        @prefix nodes: <http://data.lblod.info/form-data/nodes/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+          a form:ExactValueConstraint;
+          form:customValue "12";
+          form:grouping form:MatchSome;
+          sh:order 1;
+          sh:resultMessage "Dit veld is verplicht" .
+      `;
+
+    const report = await shaclValidateTtlCode(ttlCode);
+
+    assert.false(report.conforms);
+  });
+  test('sh:resultMessage is not a required predicate', async function (assert) {
+    const ttlCode = `
+        @prefix : <#> .
+        @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+        @prefix nodes: <http://data.lblod.info/form-data/nodes/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+          a form:ExactValueConstraint;
+          form:customValue "12";
+          form:grouping form:MatchSome;
+          sh:order 1;
+          sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40.
+      `;
+
+    const report = await shaclValidateTtlCode(ttlCode);
+
+    assert.true(report.conforms);
+  });
+  test('predicate form:customValue must be included', async function (assert) {
+    const ttlCode = `
+        @prefix : <#> .
+        @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+        @prefix nodes: <http://data.lblod.info/form-data/nodes/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+          a form:ExactValueConstraint;
+          form:grouping form:MatchSome;
+          sh:order 1;
+          sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+          sh:resultMessage "Dit veld is verplicht" .
+      `;
+
+    const report = await shaclValidateTtlCode(ttlCode);
+
+    assert.false(report.conforms);
+  });
+  test('predicate form:customValue cannot be a number', async function (assert) {
+    const ttlCode = `
+        @prefix : <#> .
+        @prefix form: <http://lblod.data.gift/vocabularies/forms/> .
+        @prefix nodes: <http://data.lblod.info/form-data/nodes/> .
+        @prefix sh: <http://www.w3.org/ns/shacl#>.
+        nodes:24289e48-258f-4919-8c3e-5783a6acb4a4
+          a form:ExactValueConstraint;
+          form:customValue 12;
+          form:grouping form:MatchSome;
+          sh:order 1;
+          sh:path nodes:e61f56db-6346-4a61-a75e-33e091789e40;
+          sh:resultMessage "Dit veld is verplicht" .
+      `;
+
+    const report = await shaclValidateTtlCode(ttlCode);
+
+    assert.false(report.conforms);
+  });
+});


### PR DESCRIPTION
## ID
 [SFB-234](https://binnenland.atlassian.net/browse/SFB-234)

 ## Description

A shape for validaiton "Exact value constraint" was not yet added to the list off shapes. With this PR we add this shape to the list so next time someone uses this validation wrong we get feedback on that.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. run the test of the exact value constraint
2. Add the validation to your field and try to make break it  by filling in data that is not supposed to be there

 ## Links to other PR's

 - /