### PR TITLE
SFB-242: unsaved changed modal when leaving codelijsten.edit

### DIFF
--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -338,21 +338,24 @@ export default class CodelijstenEditController extends Controller {
 
     if (
       this.isValidConceptSchemeName() &&
-      this.isValidConceptSchemeDescription() &&
-      this.isConceptListIncludingEmptyValues()
+      this.isValidConceptSchemeDescription()
     ) {
       if (
         this.isCodelistDescriptionDeviating() ||
-        this.isCodelistNameDeviating() ||
-        this.isConceptListChanged() ||
-        this.conceptsToDelete.length >= 1
+        this.isCodelistNameDeviating()
       ) {
         this.isSaveDisabled = false;
       } else {
         this.isSaveDisabled = true;
       }
-    } else {
-      this.isSaveDisabled = true;
+    }
+
+    if (this.isConceptListChanged() || this.conceptsToDelete.length >= 1) {
+      if (this.hasNoEmptyValuesInConceptList()) {
+        this.isSaveDisabled = false;
+      } else {
+        this.isSaveDisabled = true;
+      }
     }
   }
 
@@ -384,7 +387,7 @@ export default class CodelijstenEditController extends Controller {
     return isoDate.slice(0, 10);
   }
 
-  isConceptListIncludingEmptyValues() {
+  hasNoEmptyValuesInConceptList() {
     return this.concepts.every((concept) => concept.label.trim() !== '');
   }
 

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -336,34 +336,24 @@ export default class CodelijstenEditController extends Controller {
       return;
     }
 
-    if (this.isCodelistNameDeviating() && this.isValidConceptSchemeName()) {
-      this.isSaveDisabled = false;
-
-      return;
-    }
-
     if (
-      this.isCodelistDescriptionDeviating() &&
-      this.isValidConceptSchemeDescription()
+      this.isValidConceptSchemeName() &&
+      this.isValidConceptSchemeDescription() &&
+      this.isConceptListIncludingEmptyValues()
     ) {
-      this.isSaveDisabled = false;
-
-      return;
+      if (
+        this.isCodelistDescriptionDeviating() ||
+        this.isCodelistNameDeviating() ||
+        this.isConceptListChanged() ||
+        this.conceptsToDelete.length >= 1
+      ) {
+        this.isSaveDisabled = false;
+      } else {
+        this.isSaveDisabled = true;
+      }
+    } else {
+      this.isSaveDisabled = true;
     }
-
-    if (this.isConceptListChanged()) {
-      this.isSaveDisabled = false;
-
-      return;
-    }
-
-    if (this.conceptsToDelete.length >= 1) {
-      this.isSaveDisabled = false;
-
-      return;
-    }
-
-    this.isSaveDisabled = true;
   }
 
   @action

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -89,10 +89,11 @@ export default class CodelijstenEditController extends Controller {
   }
 
   setup = restartableTask(async (conceptSchemeId) => {
+    this.resetErrors();
     this.conceptScheme = await this.getConceptSchemeById(conceptSchemeId);
     this.setValuesFromConceptscheme();
 
-    const conceptArray = new Array(...(await this.conceptScheme.concepts));
+    const conceptArray = await this.conceptScheme.getConceptModels();
     this.setValuesFromConcepts(conceptArray);
 
     this.setIsSaveButtonDisabled();
@@ -492,5 +493,11 @@ export default class CodelijstenEditController extends Controller {
   showSaveModal(nextRoute) {
     this.isSaveModalOpen = true;
     this.nextRoute = nextRoute;
+  }
+
+  resetErrors() {
+    this.nameErrorMessage = null;
+    this.descriptionErrorMessage = null;
+    this.isDuplicateName = false;
   }
 }

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -101,7 +101,9 @@ export default class CodelijstenEditController extends Controller {
   });
 
   saveUnsavedChanges = restartableTask(async () => {
-    console.log('save unsaved changes');
+    await this.save();
+    this.isSaveModalOpen = false;
+    this.goToNextRoute();
   });
 
   setValuesFromConceptscheme() {
@@ -328,33 +330,39 @@ export default class CodelijstenEditController extends Controller {
   });
 
   setIsSaveButtonDisabled() {
-    if (this.conceptScheme.isPublic) {
-      if (this.isBackTheSavedVersion()) {
-        this.isSaveDisabled = true;
-
-        return;
-      }
-      if (
-        this.isValidConceptSchemeName() &&
-        this.isValidConceptSchemeDescription() &&
-        this.isConceptListIncludingEmptyValues()
-      ) {
-        if (
-          this.isCodelistDescriptionDeviating() ||
-          this.isCodelistNameDeviating() ||
-          this.isConceptListChanged() ||
-          this.conceptsToDelete.length >= 1
-        ) {
-          this.isSaveDisabled = false;
-        } else {
-          this.isSaveDisabled = true;
-        }
-      } else {
-        this.isSaveDisabled = true;
-      }
-    } else {
+    if (this.isReadOnly || this.isBackTheSavedVersion()) {
       this.isSaveDisabled = true;
+      return;
     }
+
+    if (this.isCodelistNameDeviating() && this.isValidConceptSchemeName()) {
+      this.isSaveDisabled = false;
+
+      return;
+    }
+
+    if (
+      this.isCodelistDescriptionDeviating() &&
+      this.isValidConceptSchemeDescription()
+    ) {
+      this.isSaveDisabled = false;
+
+      return;
+    }
+
+    if (this.isConceptListChanged()) {
+      this.isSaveDisabled = false;
+
+      return;
+    }
+
+    if (this.conceptsToDelete.length >= 1) {
+      this.isSaveDisabled = false;
+
+      return;
+    }
+
+    this.isSaveDisabled = true;
   }
 
   @action

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -215,8 +215,9 @@ export default class CodelijstenEditController extends Controller {
       this.conceptScheme.description = this.codelistDescription;
 
       try {
-        this.conceptScheme.save();
+        await this.conceptScheme.save();
         this.conceptScheme.reload();
+
         showSuccessToasterMessage(
           this.toaster,
           this.intl.t('messages.success.codelistUpdated')
@@ -311,7 +312,7 @@ export default class CodelijstenEditController extends Controller {
     this.conceptScheme.isarchived = true;
 
     try {
-      this.conceptScheme.save();
+      await this.conceptScheme.save();
       this.conceptScheme.reload();
       showSuccessToasterMessage(
         this.toaster,

--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -38,6 +38,8 @@ export default class CodelijstenEditController extends Controller {
   @tracked isArchiveModalOpen;
   @tracked isDuplicateName;
   @tracked isSaveDisabled;
+  @tracked isSaveModalOpen;
+  @tracked nextRoute;
 
   conceptsInDatabase;
 
@@ -96,6 +98,10 @@ export default class CodelijstenEditController extends Controller {
     this.setIsSaveButtonDisabled();
     // Prevent flickering between loading and showing content if small lists are shown
     await timeout(100);
+  });
+
+  saveUnsavedChanges = restartableTask(async () => {
+    console.log('save unsaved changes');
   });
 
   setValuesFromConceptscheme() {
@@ -453,5 +459,30 @@ export default class CodelijstenEditController extends Controller {
     }
 
     return !boolean;
+  }
+
+  @action
+  async discardSave() {
+    this.codelistName = this.conceptScheme.label;
+    this.codelistDescription = this.conceptScheme.description;
+    this.concepts = await this.conceptScheme.getConceptModels();
+    this.conceptsToDelete = [];
+    this.nameErrorMessage = null;
+    this.descriptionErrorMessage = null;
+
+    this.isSaveModalOpen = false;
+    this.setIsSaveButtonDisabled();
+
+    this.goToNextRoute();
+  }
+
+  @action
+  goToNextRoute() {
+    this.router.transitionTo(this.nextRoute);
+  }
+
+  showSaveModal(nextRoute) {
+    this.isSaveModalOpen = true;
+    this.nextRoute = nextRoute;
   }
 }

--- a/app/routes/codelijsten/edit.js
+++ b/app/routes/codelijsten/edit.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { service } from '@ember/service';
+import { action } from '@ember/object';
 
 export default class CodelijstenEditRoute extends Route {
   @service store;
@@ -22,5 +23,21 @@ export default class CodelijstenEditRoute extends Route {
 
   async resetController(controller) {
     await controller.removeEmptyConceptsAndScheme();
+  }
+
+  @action
+  willTransition(transition) {
+    const nextRoute = transition.targetName;
+
+    if (transition.to.parent.name == 'codelijsten.edit') {
+      return;
+    }
+
+    /* eslint ember/no-controller-access-in-routes: "warn" */
+    const editController = this.controllerFor('codelijsten.edit');
+    if (!editController.isSaveDisabled) {
+      transition.abort();
+      editController.showSaveModal(nextRoute);
+    }
   }
 }

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -231,3 +231,28 @@
     </AuButtonGroup>
   </:footer>
 </AuModal>
+
+<AuModal
+  @modalOpen={{this.isSaveModalOpen}}
+  @closeModal={{fn (mut this.isSaveModalOpen) false}}
+>
+  <:title>{{t "confirmation.saveUnsavedChangesTitle"}}</:title>
+  <:body>
+    {{t "confirmation.saveUnsavedChangesQuestion"}}
+  </:body>
+  <:footer>
+    <AuButtonGroup class="au-u-flex--between">
+      <AuButton @alert={{true}} @skin="link" {{on "click" this.discardSave}}>
+        {{t "confirmation.discardChanges"}}
+      </AuButton>
+      <AuButton
+        @loading={{this.saveUnsavedChanges.isRunning}}
+        @loadingMessage={{t "messages.loading.isSaving"}}
+        {{on "click" (perform this.saveUnsavedChanges)}}
+      >
+        {{t "confirmation.saveChanges"}}
+      </AuButton>
+
+    </AuButtonGroup>
+  </:footer>
+</AuModal>

--- a/app/utils/codelijsten/compare-concept-arrays.js
+++ b/app/utils/codelijsten/compare-concept-arrays.js
@@ -9,7 +9,7 @@ export function isConceptArrayChanged(dbConcepts, concepts) {
 
   for (const concept of concepts) {
     if (concept.label.trim() == '') {
-      return false;
+      return true;
     }
 
     if (!existingConceptIdsOnScheme.includes(concept.id)) {

--- a/app/utils/codelijsten/update-concept.js
+++ b/app/utils/codelijsten/update-concept.js
@@ -3,7 +3,7 @@ import { showErrorToasterMessage } from '../toaster-message-helper';
 export async function updateConcept(concept, store, toasterService) {
   let conceptInDatabase = await store.findRecord('concept', concept.id);
   if (concept.label.trim() == '') {
-    conceptInDatabase.destroyRecord();
+    await conceptInDatabase.destroyRecord();
   }
   if (
     concept.label.trim() == conceptInDatabase.label ||
@@ -14,7 +14,7 @@ export async function updateConcept(concept, store, toasterService) {
 
   conceptInDatabase.preflabel = concept.label;
   try {
-    conceptInDatabase.save();
+    await conceptInDatabase.save();
     conceptInDatabase.reload();
   } catch (error) {
     showErrorToasterMessage(

--- a/tests/unit/utils/codelijsten/compare-concept-arrays-test.js
+++ b/tests/unit/utils/codelijsten/compare-concept-arrays-test.js
@@ -37,7 +37,7 @@ module('Unit | Utility | Codelijsten', function () {
       const dbConcepts = [
         {
           id: 'conceptId',
-          label: '',
+          label: 'label',
         },
       ];
 


### PR DESCRIPTION
## ID
 [SFB-242](https://binnenland.atlassian.net/browse/SFB-242)

 ## Description

When routing a away from the `codelijsten.edit` route and the user has unsaved changes the user now has to confirm if they want to save or discard the changes.

The original data is set back to the current view when pressing discard. When pressing the save button it does the same as the current save button.

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Update a codelist and route back with the arrow in the breadcrumbar
2. A modal will be shown as you did not save your latest changes
3. try out both options

 ## Links to other PR's

 - /