### PR TITLE
SFB-246: Sort the concepts by order in the table

### DIFF
--- a/app/controllers/codelijsten/edit.js
+++ b/app/controllers/codelijsten/edit.js
@@ -436,6 +436,7 @@ export default class CodelijstenEditController extends Controller {
     return {
       id: model.id,
       label: model.label,
+      order: model.orderAsNumber,
     };
   }
 
@@ -526,5 +527,9 @@ export default class CodelijstenEditController extends Controller {
 
   get pageHasErrors() {
     return this.hasErrors();
+  }
+
+  get conceptsSortedByOrder() {
+    return this.conceptList.sort((a, b) => a.order - b.order);
   }
 }

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -15,7 +15,12 @@ export default class ConceptModel extends Model {
   }
 
   get orderAsNumber() {
-    return this.order ?? 0;
+    const orderAsInt = parseInt(this.order);
+    if (!isNaN(orderAsInt)) {
+      return orderAsInt;
+    }
+
+    return 0;
   }
 
   asTtlCode(conceptSchemeUri) {

--- a/app/models/concept.js
+++ b/app/models/concept.js
@@ -14,12 +14,16 @@ export default class ConceptModel extends Model {
     return this.preflabel;
   }
 
+  get orderAsNumber() {
+    return this.order ?? 0;
+  }
+
   asTtlCode(conceptSchemeUri) {
     return `
       <${this.uri}>
       ${RDF('type')} ${SKOS('Concept')} ;
       ${SKOS('prefLabel')} "${this.label}" ;
-      ${QB('order')} ${this.order ?? 0} ;
+      ${QB('order')} ${this.orderAsNumber} ;
       ${SKOS('inScheme')} <${conceptSchemeUri}> .
     `;
   }

--- a/app/templates/codelijsten/edit.hbs
+++ b/app/templates/codelijsten/edit.hbs
@@ -152,7 +152,7 @@
         </:header>
         <:body>
           {{#if this.conceptList}}
-            {{#each this.conceptList as |concept|}}
+            {{#each this.conceptsSortedByOrder as |concept|}}
               <tr>
                 {{#if this.isReadOnly}}
                   <td class="au-u-visible-medium-up">


### PR DESCRIPTION
## ID
[SFB-246](https://binnenland.atlassian.net/browse/SFB-246)

 ## Description

 We need to add an order to each concept so the user knows exactly in what order the list will be shown. To start with this I added a getter to the concept model that will always return the order as a number or 0 (zero). This way concepts without an order will be sorted on the zero value number

 ## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Other

 ## How to test

1. Make sure you have the latest backend version
2. Open a random codelist and see how it is ordered
3. Open codelist "[Opleidingen | Beurs Lokaal Bestuurlijk Talent](http://localhost:4200/codelijsten/3f514a6a-094c-4a33-b1d1-c97e59e2844a/edit)". This order should be the same as in the [migration](https://github.com/lblod/app-form-builder/commit/9ecb90ea32b70ba5ff9388bc51fc4ecfd1a9004b)

 ## Links to other PR's

 - /